### PR TITLE
Feature/gitlab checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Cursor IDE
+.history/

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -426,17 +426,12 @@ MERMAID DIAGRAM INSTRUCTIONS:
     }
 
     try {
-      setLoadingMessage('Determining wiki structure...');
-
-      // Determine which token to use based on the repository type
-      const repoUrl = repoInfo.type === 'github'
-        ? `https://github.com/${owner}/${repo}`
-        : `https://gitlab.com/${owner}/${repo}`;
+      setLoadingMessage('Determining wiki structure...');        
 
       // Prepare request body
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const requestBody: Record<string, any> = {
-        repo_url: repoUrl,
+        repo_url: repositoryInput,
         messages: [{
           role: 'user',
           content: `Analyze this GitHub repository ${owner}/${repo} and create a wiki structure for it.


### PR DESCRIPTION
- Simply use `repositoryInput` instead of constructing `repoUrl`: GitHub and GitLab accept both the web URL and the .git URL for HTTPS clones as a server‑side convenience
- Update fetching logic to use default branch variable