### PR TITLE
feat: Adding support for Ollama client

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -33,7 +33,7 @@ configs = {
     "generator_ollama": {
         "model_client": OllamaClient,
         "model_kwargs": {
-            "model": "qwen3:8b",
+            "model": "qwen3:1.7b",
             "options": {
                 "temperature": 0.7,
                 "top_p": 0.8,

--- a/api/config.py
+++ b/api/config.py
@@ -1,4 +1,4 @@
-from adalflow import GoogleGenAIClient
+from adalflow import GoogleGenAIClient, OllamaClient
 from adalflow.components.model_client.openai_client import OpenAIClient
 import os
 
@@ -20,6 +20,20 @@ configs = {
         "model_client": GoogleGenAIClient,
         "model_kwargs": {
             "model": "gemini-2.5-flash-preview-04-17",
+            "temperature": 0.7,
+            "top_p": 0.8,
+        },
+    },
+    "embedder_ollama": {
+        "model_client": OllamaClient,
+        "model_kwargs": {
+            "model": "nomic-embed-text"
+        },
+    },
+    "generator_ollama": {
+        "model_client": OllamaClient,
+        "model_kwargs": {
+            "model": "qwen3:8b",
             "temperature": 0.7,
             "top_p": 0.8,
         },

--- a/api/config.py
+++ b/api/config.py
@@ -34,8 +34,10 @@ configs = {
         "model_client": OllamaClient,
         "model_kwargs": {
             "model": "qwen3:8b",
-            "temperature": 0.7,
-            "top_p": 0.8,
+            "options": {
+                "temperature": 0.7,
+                "top_p": 0.8,
+            }
         },
     },
     "text_splitter": {

--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -226,10 +226,10 @@ def read_all_documents(path: str):
 def prepare_data_pipeline():
     """Creates and returns the data transformation pipeline."""
     splitter = TextSplitter(**configs["text_splitter"])
-    # TODO: Choose bween Ollama and OpenAI embedder
+    # TODO: Choose between Ollama and OpenAI embedder
     embedder = adal.Embedder(
         model_client=configs["embedder_ollama"]["model_client"](),
-        model_kwargs=configs["generator_ollama"]["model_kwargs"],
+        model_kwargs=configs["embedder_ollama"]["model_kwargs"],
     )
     # embedder_transformer = ToEmbeddings(
     #     embedder=embedder, batch_size=configs["embedder"]["batch_size"]

--- a/api/ollama_patch.py
+++ b/api/ollama_patch.py
@@ -1,0 +1,41 @@
+from typing import Sequence, List
+from copy import deepcopy
+from tqdm import tqdm
+import logging
+import adalflow as adal
+from adalflow.core.types import Document
+from adalflow.core.component import DataComponent
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+class OllamaDocumentProcessor(DataComponent):
+    """
+    Process documents for Ollama embeddings by processing one document at a time.
+    Adalflow Ollama Client does not support batch embedding, so we need to process each document individually.
+    """
+    def __init__(self, embedder: adal.Embedder) -> None:
+        super().__init__()
+        self.embedder = embedder
+
+    def __call__(self, documents: Sequence[Document]) -> Sequence[Document]:
+        output = deepcopy(documents)
+        logger.info(f"Processing {len(output)} documents individually for Ollama embeddings")
+
+        for i, doc in enumerate(tqdm(output, desc="Processing documents for Ollama embeddings")):
+            try:
+                # Get embedding for a single document
+                result = self.embedder(input=doc.text)
+                if result.data and len(result.data) > 0:
+                    # Assign the embedding to the document
+                    output[i].vector = result.data[0].embedding
+                else:
+                    logger.warning(f"Failed to get embedding for document {i}")
+            except Exception as e:
+                logger.error(f"Error processing document {i}: {e}")
+
+        return output

--- a/api/rag.py
+++ b/api/rag.py
@@ -295,7 +295,7 @@ IMPORTANT FORMATTING RULES:
         """
         self.initialize_db_manager()
         self.repo_url_or_path = repo_url_or_path
-        self.transformed_docs = self.db_manager.prepare_database(repo_url_or_path, access_token)
+        self.transformed_docs = self.db_manager.prepare_database(repo_url_or_path, access_token, local_ollama=local_ollama)
         logger.info(f"Loaded {len(self.transformed_docs)} documents for retrieval")
 
         retreive_embedder = self.query_embedder if local_ollama else self.embedder

--- a/api/rag.py
+++ b/api/rag.py
@@ -206,7 +206,7 @@ class RAG(adal.Component):
     """RAG with one repo.
     If you want to load a new repos, call prepare_retriever(repo_url_or_path) first."""
 
-    def __init__(self, use_s3: bool = False, local_ollama: bool = True):  # noqa: F841 - use_s3 is kept for compatibility
+    def __init__(self, use_s3: bool = False, local_ollama: bool = False):  # noqa: F841 - use_s3 is kept for compatibility
         """
         Initialize the RAG component.
 
@@ -283,7 +283,7 @@ IMPORTANT FORMATTING RULES:
         self.db_manager = DatabaseManager()
         self.transformed_docs = []
 
-    def prepare_retriever(self, repo_url_or_path: str, access_token: str = None, local_ollama: bool = True):
+    def prepare_retriever(self, repo_url_or_path: str, access_token: str = None, local_ollama: bool = False):
         """
         Prepare the retriever for a repository.
         Will load database from local storage if available.

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,4 @@ requests>=2.28.0
 jinja2>=3.1.2
 python-dotenv>=1.0.0
 openai>=1.76.2
+ollama>=0.4.8

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -58,8 +58,6 @@ class ChatCompletionRequest(BaseModel):
     filePath: Optional[str] = Field(None, description="Optional path to a file in the repository to include in the prompt")
     github_token: Optional[str] = Field(None, description="GitHub personal access token for private repositories")
     gitlab_token: Optional[str] = Field(None, description="GitLab personal access token for private repositories")
-
-    # TODO: Read this flag from the FE
     local_ollama: Optional[bool] = Field(False, description="Use locally run Ollama model for embedding and generation")
 
 @app.post("/chat/completions/stream")

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -382,8 +382,8 @@ This file contains...
                 "model": configs["generator_ollama"]["model_kwargs"]["model"],
                 "stream": True,
                 "options": {
-                    "temperature": configs["generator_ollama"]["model_kwargs"]["temperature"],
-                    "top_p": configs["generator_ollama"]["model_kwargs"]["top_p"]
+                    "temperature": configs["generator_ollama"]["model_kwargs"]["options"]["temperature"],
+                    "top_p": configs["generator_ollama"]["model_kwargs"]["options"]["top_p"]
                 }
             }
             api_kwargs = model.convert_inputs_to_api_kwargs(

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -70,7 +70,7 @@ async def chat_completions_stream(request: ChatCompletionRequest):
         if request.messages and len(request.messages) > 0:
             last_message = request.messages[-1]
             if hasattr(last_message, 'content') and last_message.content:
-                tokens = count_tokens(last_message.content)
+                tokens = count_tokens(last_message.content, local_ollama=request.local_ollama)
                 logger.info(f"Request size: {tokens} tokens")
                 if tokens > 8000:
                     logger.warning(f"Request exceeds recommended token limit ({tokens} > 7500)")

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -50,7 +50,8 @@ const addTokensToRequestBody = (
   requestBody: Record<string, any>,
   githubToken: string,
   gitlabToken: string,
-  repoType: string
+  repoType: string,
+  localOllama: boolean = false
 ): void => {
   if (githubToken && repoType === 'github') {
     requestBody.github_token = githubToken;
@@ -58,6 +59,7 @@ const addTokensToRequestBody = (
   if (gitlabToken && repoType === 'gitlab') {
     requestBody.gitlab_token = gitlabToken;
   }
+  requestBody.local_ollama = localOllama;
 };
 
 const createGithubHeaders = (githubToken: string): HeadersInit => {
@@ -97,6 +99,7 @@ export default function RepoWikiPage() {
   const githubToken = searchParams.get('github_token') || '';
   const gitlabToken = searchParams.get('gitlab_token') || '';
   const repoType = searchParams.get('type') || 'github';
+  const localOllama = searchParams.get('local_ollama') === 'true';
 
   // Initialize repo info
   const repoInfo = useMemo(() => ({
@@ -248,8 +251,8 @@ Use proper markdown formatting for code blocks and include a vertical Mermaid di
           }]
         };
 
-        // Add tokens if available
-        addTokensToRequestBody(requestBody, githubToken, gitlabToken, repoInfo.type);
+        // Add tokens and localOllama flag
+        addTokensToRequestBody(requestBody, githubToken, gitlabToken, repoInfo.type, localOllama);
 
         const response = await fetch('http://localhost:8001/chat/completions/stream', {
           method: 'POST',
@@ -414,8 +417,8 @@ IMPORTANT:
         }]
       };
 
-      // Add tokens if available
-      addTokensToRequestBody(requestBody, githubToken, gitlabToken, repoInfo.type);
+      // Add tokens and localOllama flag
+      addTokensToRequestBody(requestBody, githubToken, gitlabToken, repoInfo.type, localOllama);
 
       const response = await fetch('http://localhost:8001/chat/completions/stream', {
         method: 'POST',
@@ -1113,6 +1116,7 @@ IMPORTANT:
               }
               githubToken={githubToken}
               gitlabToken={gitlabToken}
+              localOllama={localOllama}
             />
           </div>
         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ export default function Home() {
   const [showTokenInputs, setShowTokenInputs] = useState(false);
   const [githubToken, setGithubToken] = useState('');
   const [gitlabToken, setGitlabToken] = useState('');
+  const [localOllama, setLocalOllama] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -128,6 +129,8 @@ export default function Home() {
     if (type !== 'github') {
       params.append('type', type);
     }
+    // Add local_ollama parameter
+    params.append('local_ollama', localOllama.toString());
     
     const queryString = params.toString() ? `?${params.toString()}` : '';
     
@@ -174,14 +177,28 @@ export default function Home() {
               </button>
             </div>
 
-            <div className="flex items-center">
-              <button
-                type="button"
-                onClick={() => setShowTokenInputs(!showTokenInputs)}
-                className="text-xs text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 flex items-center"
-              >
-                {showTokenInputs ? '- Hide access tokens' : '+ Add access tokens for private repositories'}
-              </button>
+            <div className="flex flex-col w-full space-y-2">
+              <div className="flex items-center">
+                <input
+                  id="local-ollama"
+                  type="checkbox"
+                  checked={localOllama}
+                  onChange={(e) => setLocalOllama(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                />
+                <label htmlFor="local-ollama" className="ml-2 text-xs text-gray-700 dark:text-gray-300">
+                  Local Ollama Model (Experimental)
+                </label>
+              </div>
+              <div className="flex items-center">
+                <button
+                  type="button"
+                  onClick={() => setShowTokenInputs(!showTokenInputs)}
+                  className="text-xs text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 flex items-center"
+                >
+                  {showTokenInputs ? '- Hide access tokens' : '+ Add access tokens for private repositories'}
+                </button>
+              </div>
             </div>
 
             {showTokenInputs && (

--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -20,9 +20,10 @@ interface AskProps {
   repoUrl: string;
   githubToken?: string;
   gitlabToken?: string;
+  localOllama?: boolean;
 }
 
-const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken }) => {
+const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken, localOllama = false }) => {
   const [question, setQuestion] = useState('');
   const [response, setResponse] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -205,7 +206,8 @@ const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken }) => {
       // Prepare the request body
       const requestBody: Record<string, unknown> = {
         repo_url: repoUrl,
-        messages: newHistory
+        messages: newHistory,
+        local_ollama: localOllama
       };
 
       // Add tokens if available
@@ -377,7 +379,8 @@ const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken }) => {
       // Prepare request body
       const requestBody: Record<string, unknown> = {
         repo_url: repoUrl,
-        messages: newHistory
+        messages: newHistory,
+        local_ollama: localOllama
       };
 
       // Add tokens if available


### PR DESCRIPTION
Sort of a PoC to make this work with Ollama Client. Currently using `nomic-embed-text` for embedding and `qwen3:8b` for generator so make sure you pull these model first.

I wanted to add some kind of toggle in the FE for switching between OpenAI/Gemini and local Ollama, but I am unfamiliar with React so I set the flag to True in the BE for now.

There are a few TODOs that need addressing to make it backward compatible. But you should be able to use this to generate  the wiki as is. Below is my result.

<img width="1206" alt="image" src="https://github.com/user-attachments/assets/e8b7f964-69be-4f0a-a0d2-f42cd385ea3b" />
