### PR TITLE
fix: customized API port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY . .
 RUN NODE_ENV=production npm run build
 
 # Expose the port the app runs on
-EXPOSE 8001 3000
+EXPOSE ${PORT:-8001} 3000
 
 # Create a script to run both backend and frontend
 RUN echo '#!/bin/bash\n\
@@ -48,8 +48,8 @@ if [ -z "$OPENAI_API_KEY" ] || [ -z "$GOOGLE_API_KEY" ]; then\n\
   echo "You can provide them via a mounted .env file or as environment variables when running the container."\n\
 fi\n\
 \n\
-# Start the API server in the background\n\
-python -m api.main &\n\
+# Start the API server in the background with the configured port\n\
+python -m api.main --port ${PORT:-8001} &\n\
 \n\
 # Start the Next.js app on port 3000 explicitly\n\
 npm run start -- -p 3000\n\
@@ -58,6 +58,7 @@ npm run start -- -p 3000\n\
 # Set environment variables
 ENV PORT=8001
 ENV NODE_ENV=production
+ENV NEXT_PUBLIC_SERVER_BASE_URL=http://localhost:${PORT:-8001}
 
 # Create empty .env file (will be overridden if one exists at runtime)
 RUN touch .env

--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ deepwiki/
 
 ### Environment Variables
 
-| Variable | Description | Required |
-|----------|-------------|----------|
+| Variable | Description | Required | Note |
+|----------|-------------|----------|------|
 | `GOOGLE_API_KEY` | Google Gemini API key for AI generation | Yes |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings | Yes |
-| `PORT` | Port for the API server (default: 8001) | No |
+| `PORT` | Port for the API server (default: 8001) | No | If you host API and frontend on the same machine, make sure change port of `NEXT_PUBLIC_SERVER_BASE_URL` accordingly |
+| `NEXT_PUBLIC_SERVER_BASE_URL` | Base URL for the API server (default: http://localhost:8001) | No |
 
 ### Docker Setup
 

--- a/api/main.py
+++ b/api/main.py
@@ -37,6 +37,6 @@ if __name__ == "__main__":
     uvicorn.run(
         "api.api:app",
         host="0.0.0.0",
-        port=8001,
+        port=port,
         reload=True
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,13 @@ services:
   deepwiki:
     build: .
     ports:
-      - "8001:8001"  # API port
+      - "${PORT:-8001}:${PORT:-8001}"  # API port
       - "3000:3000"  # Next.js port
     env_file:
       - .env
     environment:
-      - PORT=8001
+      - PORT=${PORT:-8001}
       - NODE_ENV=production
+      - NEXT_PUBLIC_SERVER_BASE_URL=http://localhost:${PORT:-8001}
     volumes:
       - ~/.adalflow:/root/.adalflow  # Persist repository and embedding data

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -900,7 +900,7 @@ IMPORTANT:
 
       <main className="flex-1 max-w-6xl mx-auto overflow-y-auto">
         {isLoading ? (
-          <div className="w-full flex flex-col items-center justify-center p-8 bg-white dark:bg-gray-800 rounded-lg shadow-lg">
+          <div className="flex flex-col items-center justify-center p-8 bg-white dark:bg-gray-800 rounded-lg shadow-lg">
             <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-purple-500 mb-4"></div>
             <p className="text-gray-800 dark:text-gray-200 text-center mb-2">
               {loadingMessage || 'Loading...'}

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -26,6 +26,8 @@ interface WikiStructure {
   pages: WikiPage[];
 }
 
+const SERVER_BASE_URL = process.env.NEXT_PUBLIC_SERVER_BASE_URL || 'http://localhost:8001';
+
 // Add CSS styles for wiki
 const wikiStyles = `
   .prose code {
@@ -251,7 +253,7 @@ Use proper markdown formatting for code blocks and include a vertical Mermaid di
         // Add tokens if available
         addTokensToRequestBody(requestBody, githubToken, gitlabToken, repoInfo.type);
 
-        const response = await fetch('http://localhost:8001/chat/completions/stream', {
+        const response = await fetch(`${SERVER_BASE_URL}/chat/completions/stream`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -417,7 +419,7 @@ IMPORTANT:
       // Add tokens if available
       addTokensToRequestBody(requestBody, githubToken, gitlabToken, repoInfo.type);
 
-      const response = await fetch('http://localhost:8001/chat/completions/stream', {
+      const response = await fetch(`${SERVER_BASE_URL}/chat/completions/stream`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -809,7 +811,7 @@ IMPORTANT:
       const repoUrl = getRepoUrl(repoInfo.owner, repoInfo.repo, repoInfo.type);
 
       // Make API call to export wiki
-      const response = await fetch('http://localhost:8001/export/wiki', {
+      const response = await fetch(`${SERVER_BASE_URL}/export/wiki`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -898,7 +900,7 @@ IMPORTANT:
 
       <main className="flex-1 max-w-6xl mx-auto overflow-y-auto">
         {isLoading ? (
-          <div className="flex flex-col items-center justify-center p-8 bg-white dark:bg-gray-800 rounded-lg shadow-lg">
+          <div className="w-full flex flex-col items-center justify-center p-8 bg-white dark:bg-gray-800 rounded-lg shadow-lg">
             <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-purple-500 mb-4"></div>
             <p className="text-gray-800 dark:text-gray-200 text-center mb-2">
               {loadingMessage || 'Loading...'}

--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -22,6 +22,8 @@ interface AskProps {
   gitlabToken?: string;
 }
 
+const SERVER_BASE_URL = process.env.NEXT_PUBLIC_SERVER_BASE_URL || 'http://localhost:8001';
+
 const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken }) => {
   const [question, setQuestion] = useState('');
   const [response, setResponse] = useState('');
@@ -217,7 +219,7 @@ const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken }) => {
       }
 
       // Make the API call
-      const apiResponse = await fetch('http://localhost:8001/chat/completions/stream', {
+      const apiResponse = await fetch(`${SERVER_BASE_URL}/chat/completions/stream`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -388,7 +390,7 @@ const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken }) => {
         requestBody.gitlab_token = gitlabToken;
       }
 
-      const apiResponse = await fetch('http://localhost:8001/chat/completions/stream', {
+      const apiResponse = await fetch(`${SERVER_BASE_URL}/chat/completions/stream`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Introduce a new environment variable `NEXT_PUBLIC_SERVER_BASE_URL`, so when backend API uses a different port or even have the logic running on another machine, frontend can always talk to backend API.