### PR TITLE
docs: change valid heading size

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm run dev
 yarn dev
 ```
 
-### Step 4: Use DeepWiki!
+#### Step 4: Use DeepWiki!
 
 1. Open [http://localhost:3000](http://localhost:3000) in your browser
 2. Enter a GitHub, GitLab, or Bitbucket repository (like `https://github.com/openai/codex`, `https://github.com/microsoft/autogen`, `https://gitlab.com/gitlab-org/gitlab`, or `https://bitbucket.org/redradish/atlassian_app_versions`)


### PR DESCRIPTION
This PR is a minor document correction. `Step X` should be `h4` .