### PR TITLE
fix: Add git to docker Image to fix git clone errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     curl \
     gnupg \
+    git \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \


### PR DESCRIPTION
When pulling a Git repository via the UI, an error occurred because git was not installed in the Docker image:
```
deepwiki-1  | 2025-05-07 07:42:59,159 - api.data_pipeline - ERROR - Failed to create repository structure: An unexpected error occurred: [Errno 2] No such file or directory: 'git'
deepwiki-1  | 2025-05-07 07:42:59,159 - api.simple_chat - ERROR - Error preparing retriever: An unexpected error occurred: [Errno 2] No such file or directory: 'git'
```
This PR adds git to the image to fix repository operations.
See also #20 