### PR TITLE
chore: Change SERVER_BASE_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ exit $?' > /app/start.sh && chmod +x /app/start.sh
 # Set environment variables
 ENV PORT=8001
 ENV NODE_ENV=production
-ENV NEXT_PUBLIC_SERVER_BASE_URL=http://localhost:${PORT:-8001}
+ENV SERVER_BASE_URL=http://localhost:${PORT:-8001}
 
 # Create empty .env file (will be overridden if one exists at runtime)
 RUN touch .env

--- a/README.kr.md
+++ b/README.kr.md
@@ -171,8 +171,8 @@ deepwiki/
 | `GOOGLE_API_KEY` | AI 생성용 Google Gemini API 키 | 예 |
 | `OPENAI_API_KEY` | 임베딩용 OpenAI API 키 | 예 |
 | `OPENROUTER_API_KEY` | 대체 모델용 OpenRouter API 키 | 아니오 | OpenRouter 모델 사용 시 필요 |
-| `PORT` | API 서버 포트 (기본값: 8001) | 아니오 | API와 프론트엔드를 같은 머신에서 호스팅 시 `NEXT_PUBLIC_SERVER_BASE_URL`의 포트도 변경 필요 |
-| `NEXT_PUBLIC_SERVER_BASE_URL` | API 서버 기본 URL (기본값: http://localhost:8001) | 아니오 |
+| `PORT` | API 서버 포트 (기본값: 8001) | 아니오 | API와 프론트엔드를 같은 머신에서 호스팅 시 `SERVER_BASE_URL`의 포트도 변경 필요 |
+| `SERVER_BASE_URL` | API 서버 기본 URL (기본값: http://localhost:8001) | 아니오 |
  
 ### Docker 설정
  

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ deepwiki/
 | `GOOGLE_API_KEY` | Google Gemini API key for AI generation | Yes |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings | Yes |
 | `OPENROUTER_API_KEY` | OpenRouter API key for alternative models | No | Required only if you want to use OpenRouter models |
-| `PORT` | Port for the API server (default: 8001) | No | If you host API and frontend on the same machine, make sure change port of `NEXT_PUBLIC_SERVER_BASE_URL` accordingly |
-| `NEXT_PUBLIC_SERVER_BASE_URL` | Base URL for the API server (default: http://localhost:8001) | No |
+| `PORT` | Port for the API server (default: 8001) | No | If you host API and frontend on the same machine, make sure change port of `SERVER_BASE_URL` accordingly |
+| `SERVER_BASE_URL` | Base URL for the API server (default: http://localhost:8001) | No |
 
 ### Docker Setup
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -171,8 +171,8 @@ deepwiki/
 | `GOOGLE_API_KEY` | Google Gemini API key  | Có |
 | `OPENAI_API_KEY` | OpenAI API key   | có |
 | `OPENROUTER_API_KEY` | OpenRouter API key   | không| Yêu cầu nếu bạn muốn dùng OpenRouter models |
-| `PORT` | Port của API server (mặc định: 8001) | không | Nếu bạn muốn chạy API và frontend trên cùng 1 máy, hãy điều chỉnh Port `NEXT_PUBLIC_SERVER_BASE_URL` |
-| `NEXT_PUBLIC_SERVER_BASE_URL` | Đường dẫnn mặt định của API server (mặc định: http://localhost:8001) | không |
+| `PORT` | Port của API server (mặc định: 8001) | không | Nếu bạn muốn chạy API và frontend trên cùng 1 máy, hãy điều chỉnh Port `SERVER_BASE_URL` |
+| `SERVER_BASE_URL` | Đường dẫnn mặt định của API server (mặc định: http://localhost:8001) | không |
 
 ### Cài Đặt với Docker 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,6 @@ services:
     environment:
       - PORT=${PORT:-8001}
       - NODE_ENV=production
-      - NEXT_PUBLIC_SERVER_BASE_URL=http://localhost:${PORT:-8001}
+      - SERVER_BASE_URL=http://localhost:${PORT:-8001}
     volumes:
       - ~/.adalflow:/root/.adalflow  # Persist repository and embedding data

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,6 @@
 import type { NextConfig } from "next";
 
-const TARGET_SERVER_BASE_URL = process.env.NEXT_PUBLIC_SERVER_BASE_URL || 'http://localhost:8001';
+const TARGET_SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'http://localhost:8001';
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 // The target backend server base URL, derived from environment variable or defaulted.
 // This should match the logic in your frontend's page.tsx for consistency.
-const TARGET_SERVER_BASE_URL = process.env.NEXT_PUBLIC_SERVER_BASE_URL || 'http://localhost:8001';
+const TARGET_SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'http://localhost:8001';
 
 export async function POST(req: NextRequest) {
   try {


### PR DESCRIPTION
Since we are using API routers for fe, no need to make `SERVER_BASE_URL` exposable to frontend.