### PR TITLE
feat: make frontend modular and add config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "deepwiki-open",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "mermaid": "^11.4.1",
         "next": "15.3.1",
         "next-intl": "^4.1.0",
@@ -19,7 +20,8 @@
         "react-syntax-highlighter": "^15.6.1",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
-        "svg-pan-zoom": "^3.6.2"
+        "svg-pan-zoom": "^3.6.2",
+        "tailwind-merge": "^3.2.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2677,6 +2679,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -8457,6 +8467,15 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/svg-pan-zoom/-/svg-pan-zoom-3.6.2.tgz",
       "integrity": "sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg=="
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
+      "integrity": "sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "mermaid": "^11.4.1",
     "next": "15.3.1",
     "next-intl": "^4.1.0",
@@ -20,7 +21,8 @@
     "react-syntax-highlighter": "^15.6.1",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
-    "svg-pan-zoom": "^3.6.2"
+    "svg-pan-zoom": "^3.6.2",
+    "tailwind-merge": "^3.2.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/types/types.ts
+++ b/src/app/types/types.ts
@@ -1,0 +1,23 @@
+// Wiki Interfaces
+export interface WikiPage {
+  id: string;
+  title: string;
+  content: string;
+  filePaths: string[];
+  importance: 'high' | 'medium' | 'low';
+  relatedPages: string[];
+}
+
+export interface WikiStructure {
+  id: string;
+  title: string;
+  description: string;
+  pages: WikiPage[];
+}
+
+export type RepoInfo = {
+  owner: string;
+  repo: string;
+  type: string;
+  localPath: string | undefined;
+}

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -5,6 +5,9 @@ import rehypeRaw from 'rehype-raw';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import Mermaid from './Mermaid';
+import { getConfig } from '@/config';
+
+const config = getConfig('wikiPage.wikiContent.sizes');
 
 interface MarkdownProps {
   content: string;
@@ -14,10 +17,10 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
   // Define markdown components
   const MarkdownComponents: React.ComponentProps<typeof ReactMarkdown>['components'] = {
     p({ children, ...props }: { children?: React.ReactNode }) {
-      return <p className="mb-1 text-xs dark:text-white" {...props}>{children}</p>;
+      return <p className={`mb-1 text-${config.p} dark:text-white`} {...props}>{children}</p>;
     },
     h1({ children, ...props }: { children?: React.ReactNode }) {
-      return <h1 className="text-base font-bold mt-3 mb-1 dark:text-white" {...props}>{children}</h1>;
+      return <h1 className={`text-${config.h1} font-bold mt-3 mb-1 dark:text-white`} {...props}>{children}</h1>;
     },
     h2({ children, ...props }: { children?: React.ReactNode }) {
       // Special styling for ReAct headings
@@ -26,7 +29,7 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
         if (text.includes('Thought') || text.includes('Action') || text.includes('Observation') || text.includes('Answer')) {
           return (
             <h2
-              className={`text-sm font-bold mt-3 mb-2 p-1 rounded ${
+              className={`text-${config.h2} font-bold mt-3 mb-2 p-1 rounded ${
                 text.includes('Thought') ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300' :
                 text.includes('Action') ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300' :
                 text.includes('Observation') ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300' :
@@ -40,28 +43,28 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
           );
         }
       }
-      return <h2 className="text-sm font-bold mt-2 mb-1 dark:text-white" {...props}>{children}</h2>;
+      return <h2 className={`text-${config.h2} font-bold mt-2 mb-1 dark:text-white`} {...props}>{children}</h2>;
     },
     h3({ children, ...props }: { children?: React.ReactNode }) {
-      return <h3 className="text-sm font-semibold mt-2 mb-1 dark:text-white" {...props}>{children}</h3>;
+      return <h3 className={`text-${config.h3} font-semibold mt-2 mb-1 dark:text-white`} {...props}>{children}</h3>;
     },
     h4({ children, ...props }: { children?: React.ReactNode }) {
-      return <h4 className="text-xs font-semibold mt-2 mb-1 dark:text-white" {...props}>{children}</h4>;
+      return <h4 className={`text-${config.h4} font-semibold mt-2 mb-1 dark:text-white`} {...props}>{children}</h4>;
     },
     ul({ children, ...props }: { children?: React.ReactNode }) {
-      return <ul className="list-disc list-inside mb-1 text-xs dark:text-white" {...props}>{children}</ul>;
+      return <ul className={`list-disc list-inside mb-1 text-${config.ul} dark:text-white`} {...props}>{children}</ul>;
     },
     ol({ children, ...props }: { children?: React.ReactNode }) {
-      return <ol className="list-decimal list-inside mb-1 text-xs dark:text-white" {...props}>{children}</ol>;
+      return <ol className={`list-decimal list-inside mb-1 text-${config.ol} dark:text-white`} {...props}>{children}</ol>;
     },
     li({ children, ...props }: { children?: React.ReactNode }) {
-      return <li className="mb-1 text-xs dark:text-white" {...props}>{children}</li>;
+      return <li className={`mb-1 text-${config.li} dark:text-white`} {...props}>{children}</li>;
     },
     a({ children, href, ...props }: { children?: React.ReactNode; href?: string }) {
       return (
         <a
           href={href}
-          className="text-purple-600 dark:text-purple-400 hover:underline"
+          className={`text-${config.a} text-purple-600 dark:text-purple-400 hover:underline`}
           target="_blank"
           rel="noopener noreferrer"
           {...props}
@@ -73,7 +76,7 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
     blockquote({ children, ...props }: { children?: React.ReactNode }) {
       return (
         <blockquote
-          className="border-l-2 border-gray-300 dark:border-gray-700 pl-2 text-gray-700 dark:text-gray-300 italic my-2"
+          className={`border-l-2 border-gray-300 dark:border-gray-700 pl-2 text-${config.blockquote} text-gray-700 dark:text-gray-300 italic my-2`}
           {...props}
         >
           {children}
@@ -83,7 +86,7 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
     table({ children, ...props }: { children?: React.ReactNode }) {
       return (
         <div className="overflow-x-auto my-2">
-          <table className="min-w-full text-xs border-collapse" {...props}>
+          <table className={`min-w-full text-${config.table} border-collapse`} {...props}>
             {children}
           </table>
         </div>
@@ -138,7 +141,7 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
       // Handle code blocks
       if (!inline && match) {
         return (
-          <div className="my-2 rounded-md overflow-hidden text-xs">
+          <div className={`my-2 rounded-md overflow-hidden text-${config.codeBlock}`}>
             <div className="bg-gray-800 text-gray-200 px-4 py-1 text-xs flex justify-between items-center">
               <span>{match[1]}</span>
               <button
@@ -167,7 +170,7 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
             <SyntaxHighlighter
               language={match[1]}
               style={tomorrow}
-              className="!text-xs"
+              className={`!text-${config.codeBlock}`}
               customStyle={{ margin: 0, borderRadius: '0 0 0.375rem 0.375rem' }}
               showLineNumbers={true}
               wrapLines={true}
@@ -183,7 +186,7 @@ const Markdown: React.FC<MarkdownProps> = ({ content }) => {
       // Handle inline code
       return (
         <code
-          className={`${className} font-mono bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-pink-500 dark:text-pink-400 text-xs`}
+          className={`${className} font-mono bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-${config.codeInline} text-pink-500 dark:text-pink-400`}
           {...otherProps}
         >
           {children}

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,0 +1,41 @@
+import ThemeToggle from "@/components/theme-toggle";
+import { t } from "@/utils/utils";
+import { Messages } from "next-intl";
+import { FaGithub, FaTwitter } from "react-icons/fa";
+import { FaCoffee } from "react-icons/fa";
+
+export default function Footer({ 
+  footerText,
+  showSocialLinks = true,
+}: { 
+  footerText: string,
+  showSocialLinks?: boolean
+}) {
+  return (
+    <footer className="max-w-6xl mx-auto flex flex-col gap-4 w-full">
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-4 bg-[var(--card-bg)] rounded-lg p-4 border border-[var(--border-color)] shadow-custom">
+          <p className="text-[var(--muted)] text-sm font-serif">{footerText}</p>
+
+          <div className="flex items-center gap-6">
+            {showSocialLinks && (
+              <div className="flex items-center space-x-5">
+                <a href="https://github.com/AsyncFuncAI/deepwiki-open" target="_blank" rel="noopener noreferrer"
+                  className="text-[var(--muted)] hover:text-[var(--accent-primary)] transition-colors">
+                  <FaGithub className="text-xl" />
+                </a>
+                <a href="https://buymeacoffee.com/sheing" target="_blank" rel="noopener noreferrer"
+                  className="text-[var(--muted)] hover:text-[var(--accent-primary)] transition-colors">
+                  <FaCoffee className="text-xl" />
+                </a>
+                <a href="https://x.com/sashimikun_void" target="_blank" rel="noopener noreferrer"
+                  className="text-[var(--muted)] hover:text-[var(--accent-primary)] transition-colors">
+                  <FaTwitter className="text-xl" />
+                </a>
+              </div>
+            )}
+            <ThemeToggle />
+          </div>
+        </div>
+      </footer>
+  );
+}

--- a/src/components/landing/AccessTokens.tsx
+++ b/src/components/landing/AccessTokens.tsx
@@ -1,0 +1,168 @@
+import { t } from "@/utils/utils";
+import { Messages } from "next-intl";
+import { FaBitbucket, FaGithub, FaGitlab } from "react-icons/fa";
+import { getConfig } from "@/config";
+import { IoKeyOutline } from "react-icons/io5";
+const config = getConfig('landingPage.advancedOptions');
+
+interface PlatformAccessTokenProps {
+  showTokenInputs: boolean;
+  setShowTokenInputs: (show: boolean) => void;
+  selectedPlatform: 'github' | 'gitlab' | 'bitbucket';
+  setSelectedPlatform: (platform: 'github' | 'gitlab' | 'bitbucket') => void;
+  accessToken: string;
+  setAccessToken: (token: string) => void;
+  messages: Messages;
+}
+
+export default function AccessTokens({
+  showTokenInputs,
+  setShowTokenInputs,
+  selectedPlatform,
+  setSelectedPlatform,
+  accessToken,
+  setAccessToken,
+  messages,
+}: PlatformAccessTokenProps) {
+  if (config.position === 'modal') {
+    return (
+      <div className="p-4 pt-0 flex flex-col gap-2">
+        <PlatformAccessToken
+          showTokenInputs={showTokenInputs}
+          setShowTokenInputs={setShowTokenInputs}
+          selectedPlatform={selectedPlatform}
+          setSelectedPlatform={setSelectedPlatform}
+          accessToken={accessToken}
+          setAccessToken={setAccessToken}
+          messages={messages}
+        />
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center relative">
+      <button
+        type="button"
+        onClick={() => setShowTokenInputs(!showTokenInputs)}
+        className="text-sm text-[var(--accent-primary)] hover:text-[var(--highlight)] flex items-center transition-colors border-b border-[var(--border-color)] hover:border-[var(--accent-primary)] pb-0.5"
+      >
+        {showTokenInputs ? t('form.hideTokens', messages) : t('form.addTokens', messages)}
+      </button>
+      {showTokenInputs && (
+        <>
+          <div className="fixed inset-0 bg-black/20 dark:bg-black/40 z-40" onClick={() => setShowTokenInputs(false)} />
+          <div className="absolute left-0 right-0 top-full mt-2 z-50">
+            <div className="flex flex-col gap-3 p-4 bg-[var(--card-bg)] rounded-lg border border-[var(--border-color)] shadow-custom card-japanese">
+              <PlatformAccessToken
+                showTokenInputs={showTokenInputs}
+                setShowTokenInputs={setShowTokenInputs}
+                selectedPlatform={selectedPlatform}
+                setSelectedPlatform={setSelectedPlatform}
+                accessToken={accessToken}
+                setAccessToken={setAccessToken}
+                messages={messages}
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PlatformAccessToken({
+  showTokenInputs,
+  setShowTokenInputs,
+  selectedPlatform,
+  setSelectedPlatform,
+  accessToken,
+  setAccessToken,
+  messages,
+}: PlatformAccessTokenProps) {
+  return (
+    <>
+      <div className="flex justify-between items-center">
+        <h3 className="text-sm font-medium text-[var(--foreground)] flex items-center gap-2">
+          <IoKeyOutline size={20} />
+          {t('form.accessToken', messages)}
+        </h3>
+        {config.position === 'embed' && (
+          <button
+            type="button"
+            onClick={() => setShowTokenInputs(false)}
+            className="text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+          >
+            <span className="sr-only">Close</span>
+            <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      <div className="bg-[var(--background)]/50 p-3 rounded-md border border-[var(--border-color)]">
+        <label className="block text-xs font-medium text-[var(--foreground)] mb-2">
+          {t('form.selectPlatform', messages)}
+        </label>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setSelectedPlatform('github')}
+            className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${
+              selectedPlatform === 'github'
+                ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
+                : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
+            }`}
+          >
+            <FaGithub className="text-lg" />
+            <span className="text-sm">GitHub</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedPlatform('gitlab')}
+            className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${
+              selectedPlatform === 'gitlab'
+                ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
+                : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
+            }`}
+          >
+            <FaGitlab className="text-lg" />
+            <span className="text-sm">GitLab</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedPlatform('bitbucket')}
+            className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${
+              selectedPlatform === 'bitbucket'
+                ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
+                : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
+            }`}
+          >
+            <FaBitbucket className="text-lg" />
+            <span className="text-sm">Bitbucket</span>
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="access-token" className="block text-xs font-medium text-[var(--foreground)] mb-2">
+          {t('form.personalAccessToken', messages, { platform: selectedPlatform.charAt(0).toUpperCase() + selectedPlatform.slice(1) })}
+        </label>
+        <input
+          id="access-token"
+          type="password"
+          value={accessToken}
+          onChange={(e) => setAccessToken(e.target.value)}
+          placeholder={t('form.tokenPlaceholder', messages, { platform: selectedPlatform.charAt(0).toUpperCase() + selectedPlatform.slice(1) })}
+          className="input-japanese block w-full px-3 py-2 rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)] text-sm"
+        />
+        <div className="flex items-center mt-2 text-xs text-[var(--muted)]">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1 text-[var(--muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {t('form.tokenSecurityNote', messages)}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/landing/AdvancedOptions.tsx
+++ b/src/components/landing/AdvancedOptions.tsx
@@ -1,0 +1,151 @@
+import { cn, t } from "@/utils/utils";
+import { Messages } from "next-intl";
+import { FaCog } from "react-icons/fa";
+import { getConfig } from "@/config";
+import { IoLanguageOutline } from "react-icons/io5";
+import { MdSelectAll } from "react-icons/md";
+
+const config = getConfig('landingPage.advancedOptions');
+
+export default function AdvancedOptions({
+  selectedLanguage,
+  setSelectedLanguage,
+  generatorModelName,
+  setGeneratorModelName,
+  availableModels,
+  setIsModelConfigModalOpen,
+  messages,
+}: {
+  selectedLanguage: string;
+  setSelectedLanguage: (language: string) => void;
+  generatorModelName: string;
+  setGeneratorModelName: (modelName: string) => void;
+  availableModels: Record<string, any>;
+  setIsModelConfigModalOpen: (open: boolean) => void;
+  messages: Messages;
+}) {
+  return (
+    <div className={cn(
+      "flex flex-wrap gap-4 items-start bg-[var(--card-bg)]/80 p-4 rounded-lg border border-[var(--border-color)] shadow-sm",
+      config.position === 'modal' && "flex-col gap-2 bg-transparent border-none shadow-none"
+    )}>
+      {/* Language selection */}
+      <div className="min-w-[140px]">
+        <label htmlFor="language-select" className={cn("text-xs font-medium text-[var(--foreground)] mb-1.5 flex items-center gap-2", config.position === 'modal' && "text-sm")}>
+          <IoLanguageOutline size={20} />
+          {t('form.wikiLanguage', messages)}
+        </label>
+        <select
+          id="language-select"
+          value={selectedLanguage}
+          onChange={(e) => setSelectedLanguage(e.target.value)}
+          className="input-japanese block w-full px-2.5 py-1.5 text-sm rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)]"
+        >
+          <option value="en">English</option>
+          <option value="ja">Japanese (日本語)</option>
+          <option value="zh">Mandarin (中文)</option>
+          <option value="es">Spanish (Español)</option>
+          <option value="kr">Korean (한국어)</option>
+          <option value="vi">Vietnamese (Tiếng Việt)</option>
+        </select>
+      </div>
+
+      {/* Model options with improved UI and explanations */}
+      <div className="flex-1 min-w-[200px]">
+        <div className="flex items-center justify-between">
+          <label htmlFor="generator-model" className={cn("text-xs font-medium text-[var(--foreground)] mb-1.5 flex items-center gap-2", config.position === 'modal' && "text-sm")}>
+            <MdSelectAll size={20} />
+            {t('form.modelSelection', messages)}
+          </label>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsModelConfigModalOpen(true)}
+              className="text-xs flex items-center gap-1 text-[var(--accent-primary)] hover:text-[var(--highlight)] transition-colors"
+              title={messages.modelConfig?.customizeTitle || "Learn how to customize models"}
+            >
+              <FaCog className="text-xs" />
+              <span>{messages.modelConfig?.customizeButton || "Customize"}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => window.open('https://github.com/AsyncFuncAI/deepwiki-open/blob/main/api/config/generators.json', '_blank')}
+              className="text-xs text-[var(--accent-primary)] hover:text-[var(--highlight)] transition-colors"
+              title={messages.modelConfig?.viewConfigTitle || "View generators.json on GitHub"}
+            >
+              {messages.modelConfig?.viewConfigButton || "View Config"}
+            </button>
+          </div>
+        </div>
+        <div className="relative">
+          <select
+            id="generator-model"
+            value={generatorModelName}
+            onChange={(e) => {
+              console.log('Selected model:', e.target.value);
+              setGeneratorModelName(e.target.value)
+            }}
+            className="input-japanese block w-full px-2.5 py-1.5 text-sm rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)]"
+            aria-describedby="model-type-description"
+          >
+            {Object.entries(availableModels).map(([key, model]) => (
+              <option key={key} value={key}>
+                {model.display_name}
+              </option>
+            ))}
+          </select>
+          <div id="model-type-description" className="absolute right-6 top-1/2 -translate-y-1/2">
+            <div className="group relative">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-[var(--muted)] cursor-help" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div className="opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-opacity absolute right-0 bottom-full mb-2 w-64 bg-[var(--card-bg)] p-2 rounded-md shadow-lg border border-[var(--border-color)] text-xs z-10">
+                <div className="font-medium mb-1">{messages.modelConfig?.availableModelTypes || "Available Model Types:"}</div>
+                <ul className="space-y-1">
+                  <li><span className="font-medium">Google:</span> {messages.modelConfig?.googleRequiresShort || "Requires GOOGLE_API_KEY"}</li>
+                  <li><span className="font-medium">Ollama:</span> {messages.modelConfig?.ollamaRequiresShort || "Local models, requires Ollama running"}</li>
+                  <li><span className="font-medium">OpenRouter:</span> {messages.modelConfig?.openrouterRequiresShort || "Requires OPENROUTER_API_KEY"}</li>
+                  <li><span className="font-medium">OpenAI:</span> {messages.modelConfig?.openaiRequiresShort || "Requires OPENAI_API_KEY"}</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* Current model type indicator */}
+        <div className="mt-2 flex items-center">
+          <div className={`px-2 py-0.5 rounded-full text-xs ${
+            generatorModelName === 'google' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' :
+            generatorModelName === 'ollama' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' :
+            generatorModelName === 'openrouter' ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' :
+            'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
+          }`}>
+            {generatorModelName === 'google' ? 'Google API' :
+            generatorModelName === 'ollama' ? 'Local Ollama' :
+            generatorModelName === 'openrouter' ? 'OpenRouter API' :
+            'API'}
+          </div>
+          {generatorModelName === 'ollama' && (
+            <div className="ml-2 text-xs text-[var(--muted)]">
+              ({messages.modelConfig?.requiresOllamaLocal || "Requires Ollama running locally"})
+            </div>
+          )}
+        </div>
+
+        <div className="mt-2 text-xs text-[var(--muted)] flex items-start">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1 text-[var(--muted)] flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span>
+            {messages.modelConfig?.configuredIn || "Models are configured in"} <code className="bg-[var(--background)]/50 px-1 rounded">api/config/generators.json</code>.
+            {messages.modelConfig?.clickHere || "Click"} <button
+              onClick={() => setIsModelConfigModalOpen(true)}
+              className="text-[var(--accent-primary)] hover:underline"
+            >
+              {messages.modelConfig?.here || "here"}
+            </button> {messages.modelConfig?.toLearnHow || "to learn how to customize models."}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/AdvancedOptionsModal.tsx
+++ b/src/components/landing/AdvancedOptionsModal.tsx
@@ -1,0 +1,47 @@
+import { Messages } from "next-intl";
+
+export default function AdvancedOptionsModal({
+  isOpen,
+  onClose,
+  content,
+  messages,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  content: React.ReactNode;
+  messages: Messages;
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Modal backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 dark:bg-black/70 z-40 transition-opacity"
+        onClick={onClose}
+      />
+      <div className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-[var(--card-bg)] z-40 transition-opacity max-w-3xl max-h-[90vh] overflow-y-auto rounded-lg shadow-custom border border-[var(--border-color)] flex flex-col">
+        <div className="sticky top-0 bg-[var(--card-bg)] border-b border-[var(--border-color)] p-4 flex justify-between items-center">
+          <h2 className="text-lg font-semibold text-[var(--foreground)]">{messages.form.advancedOptions || "Advanced Options"}</h2>
+          <button
+            onClick={onClose}
+            className="text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </div>
+        {content}
+        <div className="border-t border-[var(--border-color)] p-4 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-[var(--accent-primary)] text-white rounded-md hover:bg-[var(--accent-primary)]/90 transition-colors"
+          >
+            {messages.common?.close || "Close"}
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/wiki/Ask.tsx
+++ b/src/components/wiki/Ask.tsx
@@ -2,8 +2,10 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { FaArrowRight, FaChevronLeft, FaChevronRight } from 'react-icons/fa';
-import Markdown from './Markdown';
+import Markdown from '../Markdown';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { getConfig } from '@/config';
+import { cn } from '@/utils/utils';
 
 interface Message {
   role: 'user' | 'assistant' | 'system';
@@ -24,11 +26,12 @@ interface AskProps {
   bitbucketToken?: string;
   generatorModelName?: string;
   language?: string;
+  isAskSectionVisible?: boolean;
 }
 
-// const SERVER_BASE_URL = process.env.NEXT_PUBLIC_SERVER_BASE_URL || 'http://localhost:8001';
+const config = getConfig('wikiPage.askSection');
 
-const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken, bitbucketToken, generatorModelName, language = 'en' }) => {
+const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken, bitbucketToken, generatorModelName, language = 'en', isAskSectionVisible }) => {
   const [question, setQuestion] = useState('');
   const [response, setResponse] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -487,8 +490,10 @@ const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken, bitbucketT
     }
   };
 
+  if (!isAskSectionVisible) return null;
+  
   return (
-    <div className="w-full max-w-full">
+    <div className={cn("w-full max-w-full", config.position === 'embed' && "bg-[var(--card-bg)] backdrop-blur-md")}>
       <div className="rounded-lg overflow-hidden">
         {/* Input area */}
         <form onSubmit={handleSubmit} className="p-0">
@@ -557,7 +562,7 @@ const Ask: React.FC<AskProps> = ({ repoUrl, githubToken, gitlabToken, bitbucketT
           <div className="border-t border-gray-200 dark:border-gray-700 mt-4">
             <div
               ref={responseRef}
-              className="p-4 max-h-[500px] overflow-y-auto"
+              className="p-4 max-h-[300px] overflow-y-auto"
             >
               <Markdown content={response} />
             </div>

--- a/src/components/wiki/AskSection.tsx
+++ b/src/components/wiki/AskSection.tsx
@@ -1,0 +1,81 @@
+import { RepoInfo, WikiPage, WikiStructure } from "@/app/types/types";
+import { useState } from "react";
+import { FaChevronDown, FaChevronUp } from "react-icons/fa";
+import Ask from "@/components/wiki/Ask";
+import { cn, getRepoUrl } from "@/utils/utils";
+import { Messages } from "next-intl";
+import { getConfig } from "@/config";
+
+const config = getConfig('wikiPage.askSection');
+
+export default function AskSection({
+  wikiStructure,
+  generatedPages,
+  isLoading,
+  messages,
+  repoInfo,
+  githubToken,
+  gitlabToken,
+  bitbucketToken,
+  generatorModelName,
+  language,
+}: {
+  wikiStructure?: WikiStructure
+  generatedPages: Record<string, WikiPage>
+  isLoading: boolean
+  messages: Messages
+  repoInfo: RepoInfo
+  githubToken: string
+  gitlabToken: string
+  bitbucketToken: string
+  generatorModelName: string
+  language: string
+}) {
+  if (!config.enabled) {
+    return null;
+  }
+
+  const [isAskSectionVisible, setIsAskSectionVisible] = useState(config.defaultState === 'open' || !config.collapsible);
+  
+  return (
+    <div id="ask-section" className={cn(
+      "max-w-6xl mx-auto flex flex-col gap-4 w-full",
+      config.position === 'embed' && "sticky bottom-4 z-10 mx-4 opacity-[0.98]  w-[calc(100%-2rem)] rounded-lg"
+    )}>
+      {/* Only show Ask component when wiki is successfully generated */}
+      {wikiStructure && Object.keys(generatedPages).length > 0 && !isLoading && (
+        <div className={cn(
+          "w-full rounded-lg p-5 shadow-custom card-japanese",
+          config.position === 'embed' && "bg-[var(--card-bg)] opacity-[0.98] "
+        )}>
+          <button
+            onClick={() => {
+              if (config.collapsible) {
+                setIsAskSectionVisible(!isAskSectionVisible)
+              }
+            }}
+            className="w-full flex items-center justify-between text-left mb-3 text-sm font-serif text-[var(--foreground)] hover:text-[var(--accent-primary)] transition-colors"
+            aria-expanded={isAskSectionVisible}
+          >
+            <span>
+              {messages.repoPage?.askAboutRepo || 'Ask questions about this repository'}
+            </span>
+            {!config.collapsible ? null : isAskSectionVisible ? <FaChevronUp /> : <FaChevronDown />}
+          </button>
+          <Ask
+            repoUrl={repoInfo.owner && repoInfo.repo
+              ? getRepoUrl(repoInfo.owner, repoInfo.repo, repoInfo.type, repoInfo.localPath)
+              : "https://github.com/AsyncFuncAI/deepwiki-open"
+            }
+            githubToken={githubToken}
+            gitlabToken={gitlabToken}
+            bitbucketToken={bitbucketToken}
+            generatorModelName={generatorModelName}
+            language={language}
+            isAskSectionVisible={isAskSectionVisible}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/wiki/WikiDocLoading.tsx
+++ b/src/components/wiki/WikiDocLoading.tsx
@@ -1,0 +1,82 @@
+import { WikiPage, WikiStructure } from "@/app/types/types"
+import { Messages } from "next-intl"
+
+export default function WikiDocLoading({
+  loadingMessage,
+  isExporting,
+  messages,
+  wikiStructure,
+  pagesInProgress,
+  language,
+}: {
+  loadingMessage?: string
+  isExporting: boolean
+  messages: Messages
+  wikiStructure?: WikiStructure
+  pagesInProgress: Set<string>
+  language: string
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center p-8 bg-[var(--card-bg)] rounded-lg shadow-custom card-japanese">
+      <div className="relative mb-6">
+        <div className="absolute -inset-4 bg-[var(--accent-primary)]/10 rounded-full blur-md animate-pulse"></div>
+        <div className="relative flex items-center justify-center">
+          <div className="w-3 h-3 bg-[var(--accent-primary)]/70 rounded-full animate-pulse"></div>
+          <div className="w-3 h-3 bg-[var(--accent-primary)]/70 rounded-full animate-pulse delay-75 mx-2"></div>
+          <div className="w-3 h-3 bg-[var(--accent-primary)]/70 rounded-full animate-pulse delay-150"></div>
+        </div>
+      </div>
+      <p className="text-[var(--foreground)] text-center mb-3 font-serif">
+        {loadingMessage || messages.common?.loading || 'Loading...'}
+        {isExporting && (messages.loading?.preparingDownload || ' Please wait while we prepare your download...')}
+      </p>
+
+      {/* Progress bar for page generation */}
+      {wikiStructure && (
+        <div className="w-full max-w-md mt-3">
+          <div className="bg-[var(--background)]/50 rounded-full h-2 mb-3 overflow-hidden border border-[var(--border-color)]">
+            <div
+              className="bg-[var(--accent-primary)] h-2 rounded-full transition-all duration-300 ease-in-out"
+              style={{
+                width: `${Math.max(5, 100 * (wikiStructure.pages.length - pagesInProgress.size) / wikiStructure.pages.length)}%`
+              }}
+            />
+          </div>
+          <p className="text-xs text-[var(--muted)] text-center">
+            {language === 'ja'
+              ? `${wikiStructure.pages.length}ページ中${wikiStructure.pages.length - pagesInProgress.size}ページ完了`
+              : messages.repoPage?.pagesCompleted
+                  ? messages.repoPage.pagesCompleted
+                      .replace('{completed}', (wikiStructure.pages.length - pagesInProgress.size).toString())
+                      .replace('{total}', wikiStructure.pages.length.toString())
+                  : `${wikiStructure.pages.length - pagesInProgress.size} of ${wikiStructure.pages.length} pages completed`}
+          </p>
+
+          {/* Show list of in-progress pages */}
+          {pagesInProgress.size > 0 && (
+            <div className="mt-4 text-xs">
+              <p className="text-[var(--muted)] mb-2">
+                {messages.repoPage?.currentlyProcessing || 'Currently processing:'}
+              </p>
+              <ul className="text-[var(--foreground)] space-y-1">
+                {Array.from(pagesInProgress).slice(0, 3).map(pageId => {
+                  const page = wikiStructure.pages.find((p: WikiPage) => p.id === pageId);
+                  return page ? <li key={pageId} className="truncate border-l-2 border-[var(--accent-primary)]/30 pl-2">{page.title}</li> : null;
+                })}
+                {pagesInProgress.size > 3 && (
+                  <li className="text-[var(--muted)]">
+                    {language === 'ja'
+                      ? `...他に${pagesInProgress.size - 3}ページ`
+                      : messages.repoPage?.andMorePages
+                          ? messages.repoPage.andMorePages.replace('{count}', (pagesInProgress.size - 3).toString())
+                          : `...and ${pagesInProgress.size - 3} more`}
+                  </li>
+                )}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,83 @@
+export const config = {
+  landingPage: {
+    advancedOptions: {
+      /*
+      position: modal | embed
+      */
+      position: 'modal'
+    }
+  },
+  wikiPage: {
+    askSection: {
+      /*
+      enabled: true | false
+      */
+      enabled: true,
+      /* 
+      position: bottom | top | embed
+      */
+      position: 'bottom',
+      /*
+      collapsible: true | false
+      */
+      collapsible: true,
+      /*
+      defaultState: open | closed
+      */
+      defaultState: 'open',
+    },
+    exportWiki:{
+      /*
+      markdown: true | false
+      */
+      markdown: true,
+      /*
+      json: true | false
+      */
+      json: true
+    },
+    wikiContent: {
+      sizes: {
+        /*
+          Sizes for the markdown content using tailwindcss classes (https://tailwindcss.com/docs/font-size#using-a-custom-value)
+          Default sizes are:
+          p: 'xs',
+          h1: 'base',
+          h2: 'sm',
+          h3: 'sm',
+          h4: 'xs',
+          ul: 'xs',
+          ol: 'xs',
+          li: 'xs',
+          a: 'xs',
+          blockquote: 'xs',
+          table: 'xs',
+          codeBlock: 'xs',
+          codeInline: 'xs'
+        */
+        p: 'xs',
+        h1: 'base',
+        h2: 'sm',
+        h3: 'sm',
+        h4: 'xs',
+        ul: 'xs',
+        ol: 'xs',
+        li: 'xs',
+        a: 'xs',
+        blockquote: 'xs',
+        table: 'xs',
+        codeBlock: 'xs',
+        codeInline: 'xs'
+      }
+    }
+  }
+}
+
+export const getConfig = (path: string) => {
+  const keys = path.split('.');
+  let result: any = config;
+  for (const key of keys) {
+    result = result[key];
+  }
+  return result;
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -47,7 +47,8 @@
     "selectPlatform": "Select Platform",
     "personalAccessToken": "{platform} Personal Access Token",
     "tokenPlaceholder": "Enter your {platform} token",
-    "tokenSecurityNote": "Token is stored in memory only and never persisted."
+    "tokenSecurityNote": "Token is stored in memory only and never persisted.",
+    "advancedOptions": "Advanced Options"
   },
   "footer": {
     "copyright": "DeepWiki - AI-powered documentation for code repositories"
@@ -69,8 +70,8 @@
     "errorMessageDefault": "Please check that your repository exists and is public. Valid formats are \"owner/repo\", \"https://github.com/owner/repo\", \"https://gitlab.com/owner/repo\", \"https://bitbucket.org/owner/repo\", or local folder paths like \"C:\\\\path\\\\to\\\\folder\" or \"/path/to/folder\".",
     "backToHome": "Back to Home",
     "exportWiki": "Export Wiki",
-    "exportAsMarkdown": "Export as Markdown",
-    "exportAsJson": "Export as JSON",
+    "exportAsMarkdown": "Markdown",
+    "exportAsJson": "JSON",
     "pages": "Pages",
     "relatedFiles": "Related Files:",
     "relatedPages": "Related Pages:",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -47,7 +47,8 @@
     "selectPlatform": "Seleccionar Plataforma",
     "personalAccessToken": "Token de Acceso Personal de {platform}",
     "tokenPlaceholder": "Ingresa tu token de {platform}",
-    "tokenSecurityNote": "El token solo se almacena en memoria y nunca se persiste."
+    "tokenSecurityNote": "El token solo se almacena en memoria y nunca se persiste.",
+    "advancedOptions": "Opciones Avanzadas"
   },
   "footer": {
     "copyright": "DeepWiki - Documentación impulsada por IA para repositorios de código"
@@ -69,8 +70,8 @@
     "errorMessageDefault": "Por favor, verifica que tu repositorio existe y es público. Los formatos válidos son \"owner/repo\", \"https://github.com/owner/repo\", \"https://gitlab.com/owner/repo\", \"https://bitbucket.org/owner/repo\", o rutas de carpetas locales como \"C:\\\\path\\\\to\\\\folder\" o \"/path/to/folder\".",
     "backToHome": "Volver al Inicio",
     "exportWiki": "Exportar Wiki",
-    "exportAsMarkdown": "Exportar como Markdown",
-    "exportAsJson": "Exportar como JSON",
+    "exportAsMarkdown": "Markdown",
+    "exportAsJson": "JSON",
     "pages": "Páginas",
     "relatedFiles": "Archivos Relacionados:",
     "relatedPages": "Páginas Relacionadas:",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -47,7 +47,8 @@
     "selectPlatform": "プラットフォームを選択",
     "personalAccessToken": "{platform}個人アクセストークン",
     "tokenPlaceholder": "{platform}トークンを入力してください",
-    "tokenSecurityNote": "トークンはメモリ内にのみ保存され、永続化されることはありません。"
+    "tokenSecurityNote": "トークンはメモリ内にのみ保存され、永続化されることはありません。",
+    "advancedOptions": "高度なオプション"
   },
   "footer": {
     "copyright": "DeepWiki - コードリポジトリのためのAI駆動ドキュメンテーション"
@@ -69,8 +70,8 @@
     "errorMessageDefault": "リポジトリが存在し、公開されていることを確認してください。有効な形式は「owner/repo」、「https://github.com/owner/repo」、「https://gitlab.com/owner/repo」、「https://bitbucket.org/owner/repo」、またはローカルフォルダパス（例: 「C:\\\\path\\\\to\\\\folder」、「/path/to/folder」）です。",
     "backToHome": "ホームに戻る",
     "exportWiki": "Wikiをエクスポート",
-    "exportAsMarkdown": "Markdownとしてエクスポート",
-    "exportAsJson": "JSONとしてエクスポート",
+    "exportAsMarkdown": "Markdown",
+    "exportAsJson": "JSON",
     "pages": "ページ",
     "relatedFiles": "関連ファイル:",
     "relatedPages": "関連ページ:",

--- a/src/messages/kr.json
+++ b/src/messages/kr.json
@@ -47,7 +47,8 @@
       "selectPlatform": "플랫폼 선택",
       "personalAccessToken": "{platform} 개인 액세스 토큰",
       "tokenPlaceholder": "{platform} 토큰을 입력하세요",
-      "tokenSecurityNote": "토큰은 메모리에만 저장되며, 영구적으로 보존되지 않습니다."
+      "tokenSecurityNote": "토큰은 메모리에만 저장되며, 영구적으로 보존되지 않습니다.",
+      "advancedOptions": "고급 옵션"
     },
     "footer": {
       "copyright": "DeepWiki - 코드 저장소를 위한 AI 기반 문서화"
@@ -69,8 +70,8 @@
       "errorMessageDefault": "저장소가 존재하며 공개 상태인지 확인해 주세요. 유효한 형식은 \"owner/repo\", \"https://github.com/owner/repo\", \"https://gitlab.com/owner/repo\", \"https://bitbucket.org/owner/repo\" 또는 로컬 폴더 경로 \"C:\\\\path\\\\to\\\\folder\" 혹은 \"/path/to/folder\" 입니다.",
       "backToHome": "홈으로 돌아가기",
       "exportWiki": "위키 내보내기",
-      "exportAsMarkdown": "마크다운으로 내보내기",
-      "exportAsJson": "JSON으로 내보내기",
+      "exportAsMarkdown": "마크다운",
+      "exportAsJson": "JSON",
       "pages": "페이지",
       "relatedFiles": "관련 파일:",
       "relatedPages": "관련 페이지:",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -47,7 +47,8 @@
     "selectPlatform": "Chọn nền tảng",
     "personalAccessToken": "Token truy cập cá nhân {platform}",
     "tokenPlaceholder": "Nhập token {platform} của bạn",
-    "tokenSecurityNote": "Token chỉ được lưu trong bộ nhớ và không bao giờ được lưu trữ vĩnh viễn."
+    "tokenSecurityNote": "Token chỉ được lưu trong bộ nhớ và không bao giờ được lưu trữ vĩnh viễn.",
+    "advancedOptions": "Tùy chọn nâng cao"
   },
   "footer": {
     "copyright": "DeepWiki - Tài liệu hỗ trợ bởi AI cho repository"
@@ -69,8 +70,8 @@
     "errorMessageDefault": "Vui lòng kiểm tra xem repository có tồn tại và công khai hay không. Các định dạng hợp lệ là \"owner/repo\", \"https://github.com/owner/repo\", \"https://gitlab.com/owner/repo\", \"https://bitbucket.org/owner/repo\", hoặc các đường dẫn thư mục cục bộ như \"C:\\\\path\\\\to\\\\folder\" hoặc \"/path/to/folder\".",
     "backToHome": "Quay lại trang chủ",
     "exportWiki": "Xuất Wiki",
-    "exportAsMarkdown": "Xuất dưới dạng Markdown",
-    "exportAsJson": "Xuất dưới dạng JSON",
+    "exportAsMarkdown": "Markdown",
+    "exportAsJson": "JSON",
     "pages": "Trang",
     "relatedFiles": "Tệp liên quan:",
     "relatedPages": "Trang liên quan:",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -47,7 +47,8 @@
     "selectPlatform": "选择平台",
     "personalAccessToken": "{platform}个人访问令牌",
     "tokenPlaceholder": "输入您的{platform}令牌",
-    "tokenSecurityNote": "令牌仅存储在内存中，从不持久化。"
+    "tokenSecurityNote": "令牌仅存储在内存中，从不持久化。",
+    "advancedOptions": "高级选项"
   },
   "footer": {
     "copyright": "DeepWiki - 为代码仓库提供AI驱动的文档"
@@ -69,8 +70,8 @@
     "errorMessageDefault": "请检查您的仓库是否存在且为公开的。有效格式为\"owner/repo\"、\"https://github.com/owner/repo\"、\"https://gitlab.com/owner/repo\"、\"https://bitbucket.org/owner/repo\"，或本地文件夹路径如\"C:\\\\path\\\\to\\\\folder\"或\"/path/to/folder\"。",
     "backToHome": "返回首页",
     "exportWiki": "导出Wiki",
-    "exportAsMarkdown": "导出为Markdown",
-    "exportAsJson": "导出为JSON",
+    "exportAsMarkdown": "Markdown",
+    "exportAsJson": "JSON",
     "pages": "页面",
     "relatedFiles": "相关文件：",
     "relatedPages": "相关页面：",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,47 @@
+import { Messages } from "next-intl";
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+// Create a simple translation function
+export const t = (key: string, messages: Messages, params: Record<string, string | number> = {}): string => {
+  // Split the key by dots to access nested properties
+  const keys = key.split('.');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let value: any = messages;
+
+  // Navigate through the nested properties
+  for (const k of keys) {
+    if (value && typeof value === 'object' && k in value) {
+      value = value[k];
+    } else {
+      // Return the key if the translation is not found
+      return key;
+    }
+  }
+
+  // If the value is a string, replace parameters
+  if (typeof value === 'string') {
+    return Object.entries(params).reduce((acc: string, [paramKey, paramValue]) => {
+      return acc.replace(`{${paramKey}}`, String(paramValue));
+    }, value);
+  }
+
+  // Return the key if the value is not a string
+  return key;
+};
+
+// Helper functions for token handling and API requests
+export const getRepoUrl = (owner: string, repo: string, repoType: string, localPath?: string): string => {
+  if (repoType === 'local' && localPath) {
+    return localPath;
+  }
+  return repoType === 'github'
+    ? `https://github.com/${owner}/${repo}`
+    : repoType === 'gitlab'
+    ? `https://gitlab.com/${owner}/${repo}`
+    : `https://bitbucket.org/${owner}/${repo}`;
+};


### PR DESCRIPTION
1. Move some components as separate components file.
2. Add `config.ts` as frontend configuration file.
  a. advanced options position can be `modal` or `embed`
  b. wiki page ask section position can be `top` | `bottom` | `embed`
  c. export wiki as markdown and json buttons can be enabled or disabled
  d. wiki content text size can be configured

Examples:
1. advanced options position as `modal`
<img width="1170" alt="Screenshot 2025-05-10 at 9 27 51 PM" src="https://github.com/user-attachments/assets/10f3a72e-44a6-40b1-99c1-c9c2454f7243" />


2. ask section position as `embed`
<img width="1192" alt="Screenshot 2025-05-10 at 9 28 32 PM" src="https://github.com/user-attachments/assets/4b7f7aae-d76d-41c9-97dc-f4aa812e6db8" />

3. Having sizes as
```
        p: 'base',
        h1: 'lg',
        h2: 'lg',
        h3: 'base',
        h4: 'base',
        ul: 'base',
        ol: 'base',
        li: 'base',
        a: 'base',
        blockquote: 'base',
        table: 'base',
        codeBlock: 'base',
        codeInline: 'base'
```
<img width="1188" alt="Screenshot 2025-05-10 at 9 31 06 PM" src="https://github.com/user-attachments/assets/dc196897-021d-4d0b-b8f6-4e5ea12b9c99" />

