### PR TITLE
Fix .env port conflict between backend and frontend (Next.js) when running on the same device

### DIFF
--- a/Ollama-instruction.md
+++ b/Ollama-instruction.md
@@ -46,8 +46,15 @@ cd deepwiki-open
 Create a `.env` file in the project root:
 ```
 # No need for API keys when using Ollama locally
-PORT=8001
+Server_PORT=8001
 ```
+
+
+**Note:**  
+- If you run both frontend (React/Next.js) and backend (API server) on the same device, make sure they use different ports.  
+- For example, set `Server_PORT=8001` for the backend and leave the frontend to use its default port 8001.  
+- Then add `SERVER_BASE_URL=http://localhost:8001` in `.env` so the frontend can communicate with the backend.
+- Use `Server_PORT` instead of `PORT` to prevent frontend take it into configuration if frontend and backend running on identical device. 
 
 Start the backend:
 ```bash

--- a/api/main.py
+++ b/api/main.py
@@ -40,7 +40,7 @@ if missing_vars:
 
 if __name__ == "__main__":
     # Get port from environment variable or use default
-    port = int(os.environ.get("PORT", 8001))
+    port = int(os.environ.get("Server_PORT", 8001))
 
     # Import the app here to ensure environment variables are set first
     from api.api import app


### PR DESCRIPTION
Hi there,

As mentioned by #114, the issue occurs because both the backend and the Next.js frontend read the PORT variable from .env. 
(I suspect it, not for sure, but experimented) Setting `PORT=8001` causes both to try to use the same port, resulting in a conflict.

## Solution
- Use `Server_PORT` instead of `PORT` in `.env`, and updated backend code to read from `Server_PORT` instead of `PORT`.
- Updated documentation and .env usage to recommend using Server_PORT (or SERVER_PORT) for the backend, and leaving PORT for the frontend.
- Added a note to use `SERVER_BASE_URL` in the .env to point to the backend.

This resolves the port conflict and allows both servers to run simultaneously on the same device.