### PR TITLE
fix: repo_url is empty when ask but failed

### DIFF
--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -250,6 +250,7 @@ const Ask: React.FC<AskProps> = ({
       // Prepare the request body
       const requestBody: ChatCompletionRequest = {
         repo_url: getRepoUrl(repoInfo),
+        type: repoInfo.type,
         messages: newHistory.map(msg => ({ role: msg.role as 'user' | 'assistant', content: msg.content })),
         provider: selectedProvider,
         model: isCustomSelectedModel ? customSelectedModel : selectedModel,
@@ -491,6 +492,7 @@ const Ask: React.FC<AskProps> = ({
       // Prepare request body
       const requestBody: ChatCompletionRequest = {
         repo_url: getRepoUrl(repoInfo),
+        type: repoInfo.type,
         messages: newHistory.map(msg => ({ role: msg.role as 'user' | 'assistant', content: msg.content })),
         provider: selectedProvider,
         model: isCustomSelectedModel ? customSelectedModel : selectedModel,

--- a/src/utils/getRepoUrl.tsx
+++ b/src/utils/getRepoUrl.tsx
@@ -5,6 +5,13 @@ export default function getRepoUrl(repoInfo: RepoInfo): string {
   if (repoInfo.type === 'local' && repoInfo.localPath) {
     return repoInfo.localPath;
   } else {
-    return repoInfo.repoUrl || '';
+    if(repoInfo.repoUrl) {
+      return repoInfo.repoUrl;
+    } else {
+      if(repoInfo.owner && repoInfo.repo) {
+        return "http://example/" + repoInfo.owner + "/" + repoInfo.repo;
+      }
+      return '';
+    }
   }
 };


### PR DESCRIPTION
Ask does not work when the url likes "/{owner}/{repo}?type=gitlab&language=zh" which without the repo_url.
Only need to provide a mock url for resolving the repo info by backend because the repo has been stored when asking.