### PR TITLE
replace environment variable OPENAI_API_BASE with OPENAI_BASE_URL to align with OPENAI standard

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -193,7 +193,7 @@ OPENAI_API_KEY=tu_clave_api_openai        # Requerida para modelos OpenAI
 OPENROUTER_API_KEY=tu_clave_api_openrouter # Requerida para modelos OpenRouter
 
 # Configuración de URL Base de OpenAI API
-OPENAI_API_BASE=https://punto-final-personalizado.com/v1  # Opcional, para endpoints personalizados de OpenAI API
+OPENAI_BASE_URL=https://punto-final-personalizado.com/v1  # Opcional, para endpoints personalizados de OpenAI API
 
 # Directorio de Configuración
 DEEPWIKI_CONFIG_DIR=/ruta/a/directorio/config/personalizado  # Opcional, para ubicación personalizada de archivos de configuración

--- a/README.ja.md
+++ b/README.ja.md
@@ -315,7 +315,7 @@ OPENAI_API_KEY=あなたのOpenAI鍵            # OpenAIモデルに必要
 OPENROUTER_API_KEY=あなたのOpenRouter鍵    # OpenRouterモデルに必要
 
 # OpenAI APIベースURL設定
-OPENAI_API_BASE=https://カスタムAPIエンドポイント.com/v1  # オプション、カスタムOpenAI APIエンドポイント用
+OPENAI_BASE_URL=https://カスタムAPIエンドポイント.com/v1  # オプション、カスタムOpenAI APIエンドポイント用
 ```
 
 ### サービスプロバイダー向けのカスタムモデル選択

--- a/README.kr.md
+++ b/README.kr.md
@@ -1,23 +1,23 @@
 # DeepWiki-Open
 
 ![DeepWiki Banner](screenshots/Deepwiki.png)
- 
+
 **DeepWiki**는 제가 직접 구현한 프로젝트로, GitHub, GitLab 또는 BitBucket 저장소에 대해 아름답고 대화형 위키를 자동 생성합니다! 저장소 이름만 입력하면 DeepWiki가 다음을 수행합니다:
- 
+
 1. 코드 구조 분석
 2. 포괄적인 문서 생성
 3. 모든 작동 방식을 설명하는 시각적 다이어그램 생성
 4. 이를 쉽게 탐색할 수 있는 위키로 정리
- 
+
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://buymeacoffee.com/sheing)
- 
+
 [![Twitter/X](https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white)](https://x.com/sashimikun_void)
 [![Discord](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/invite/VQMBGR8u5v)
- 
+
 [English](./README.md) | [简体中文](./README.zh.md) | [日本語](./README.ja.md) | [Español](./README.es.md) | [한국어](./README.kr.md) | [Tiếng Việt](./README.vi.md)
- 
+
 ## ✨ 주요 기능
- 
+
 - **즉시 문서화**: 어떤 GitHub, GitLab 또는 BitBucket 저장소든 몇 초 만에 위키로 변환
 - **비공개 저장소 지원**: 개인 액세스 토큰으로 비공개 저장소 안전하게 접근
 - **스마트 분석**: AI 기반 코드 구조 및 관계 이해
@@ -26,78 +26,78 @@
 - **Ask 기능**: RAG 기반 AI와 저장소에 대해 대화하며 정확한 답변 얻기
 - **DeepResearch**: 복잡한 주제를 철저히 조사하는 다중 턴 연구 프로세스
 - **다양한 모델 제공자 지원**: Google Gemini, OpenAI, OpenRouter, 로컬 Ollama 모델 지원
- 
+
 ## 🚀 빠른 시작 (초간단!)
- 
+
 ### 옵션 1: Docker 사용
- 
+
 ```bash
 # 저장소 클론
 git clone https://github.com/AsyncFuncAI/deepwiki-open.git
 cd deepwiki-open
- 
+
 # API 키를 포함한 .env 파일 생성
 echo "GOOGLE_API_KEY=your_google_api_key" > .env
 echo "OPENAI_API_KEY=your_openai_api_key" >> .env
 # 선택 사항: OpenRouter 모델 사용 시 API 키 추가
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" >> .env
- 
+
 # Docker Compose로 실행
 docker-compose up
 ```
- 
+
 > 💡 **API 키는 어디서 얻나요:**
 > - [Google AI Studio](https://makersuite.google.com/app/apikey)에서 Google API 키 받기
 > - [OpenAI 플랫폼](https://platform.openai.com/api-keys)에서 OpenAI API 키 받기
- 
+
 ### 옵션 2: 수동 설정 (권장)
- 
+
 #### 1단계: API 키 설정
- 
+
 프로젝트 루트에 `.env` 파일을 만들고 다음 키들을 추가하세요:
- 
+
 ```
 GOOGLE_API_KEY=your_google_api_key
 OPENAI_API_KEY=your_openai_api_key
 # 선택 사항: OpenRouter 모델 사용 시 추가
 OPENROUTER_API_KEY=your_openrouter_api_key
 ```
- 
+
 #### 2단계: 백엔드 시작
- 
+
 ```bash
 # Python 의존성 설치
 pip install -r api/requirements.txt
- 
+
 # API 서버 실행
 python -m api.main
 ```
- 
+
 #### 3단계: 프론트엔드 시작
- 
+
 ```bash
 # JavaScript 의존성 설치
 npm install
 # 또는
 yarn install
- 
+
 # 웹 앱 실행
 npm run dev
 # 또는
 yarn dev
 ```
- 
+
 #### 4단계: DeepWiki 사용하기!
- 
+
 1. 브라우저에서 [http://localhost:3000](http://localhost:3000) 열기
 2. GitHub, GitLab 또는 Bitbucket 저장소 입력 (예: `https://github.com/openai/codex`, `https://github.com/microsoft/autogen`, `https://gitlab.com/gitlab-org/gitlab`, `https://bitbucket.org/redradish/atlassian_app_versions`)
 3. 비공개 저장소인 경우 "+ 액세스 토큰 추가" 클릭 후 GitHub 또는 GitLab 개인 액세스 토큰 입력
 4. "Generate Wiki" 클릭 후 마법을 지켜보기!
- 
+
 ## 🔍 작동 방식
- 
+
 DeepWiki는 AI를 사용하여 다음을 수행합니다:
- 
+
 1. GitHub, GitLab 또는 Bitbucket 저장소 복제 및 분석 (토큰 인증이 필요한 비공개 저장소 포함)
 2. 스마트 검색을 위한 코드 임베딩 생성
 3. 문맥 인지 AI로 문서 생성 (Google Gemini, OpenAI, OpenRouter 또는 로컬 Ollama 모델 사용)
@@ -105,7 +105,7 @@ DeepWiki는 AI를 사용하여 다음을 수행합니다:
 5. 모든 것을 구조화된 위키로 정리
 6. Ask 기능을 통한 저장소와의 지능형 Q&A 지원
 7. DeepResearch로 심층 연구 기능 제공
- 
+
 ```mermaid
 graph TD
     A[사용자가 GitHub/GitLab/Bitbucket 저장소 입력] --> AA{비공개 저장소인가?}
@@ -114,36 +114,36 @@ graph TD
     AB --> B
     B --> C[코드 구조 분석]
     C --> D[코드 임베딩 생성]
- 
+
     D --> M{모델 제공자 선택}
     M -->|Google Gemini| E1[Gemini로 생성]
     M -->|OpenAI| E2[OpenAI로 생성]
     M -->|OpenRouter| E3[OpenRouter로 생성]
     M -->|로컬 Ollama| E4[Ollama로 생성]
- 
+
     E1 --> E[문서 생성]
     E2 --> E
     E3 --> E
     E4 --> E
- 
+
     D --> F[시각적 다이어그램 생성]
     E --> G[위키로 정리]
     F --> G
     G --> H[대화형 DeepWiki]
- 
+
     classDef process stroke-width:2px;
     classDef data stroke-width:2px;
     classDef result stroke-width:2px;
     classDef decision stroke-width:2px;
- 
+
     class A,D data;
     class AA,M decision;
     class B,C,E,F,G,AB,E1,E2,E3,E4 process;
     class H result;
 ```
- 
+
 ## 🛠️ 프로젝트 구조
- 
+
 ```
 deepwiki/
 ├── api/                  # 백엔드 API 서버
@@ -163,11 +163,11 @@ deepwiki/
 ├── package.json          # JavaScript 의존성
 └── .env                  # 환경 변수 (직접 생성)
 ```
- 
+
 ## 🛠️ 고급 설정
- 
+
 ### 환경 변수
- 
+
 | 변수명 | 설명 | 필수 | 비고 |
 |----------|-------------|----------|------|
 | `GOOGLE_API_KEY` | AI 생성용 Google Gemini API 키 | 예 |
@@ -175,7 +175,7 @@ deepwiki/
 | `OPENROUTER_API_KEY` | 대체 모델용 OpenRouter API 키 | 아니오 | OpenRouter 모델 사용 시 필요 |
 | `PORT` | API 서버 포트 (기본값: 8001) | 아니오 | API와 프론트엔드를 같은 머신에서 호스팅 시 `SERVER_BASE_URL`의 포트도 변경 필요 |
 | `SERVER_BASE_URL` | API 서버 기본 URL (기본값: http://localhost:8001) | 아니오 |
- 
+
 ### 설정 파일
 
 DeepWiki는 시스템의 다양한 측면을 관리하기 위해 JSON 설정 파일을 사용합니다:
@@ -197,13 +197,13 @@ DeepWiki는 시스템의 다양한 측면을 관리하기 위해 JSON 설정 파
 기본적으로 이러한 파일은 `api/config/` 디렉토리에 위치합니다. `DEEPWIKI_CONFIG_DIR` 환경 변수를 사용하여 위치를 사용자 정의할 수 있습니다.
 
 ### Docker 설정
- 
+
 Docker를 사용하여 DeepWiki를 실행할 수 있습니다:
- 
+
 ```bash
 # GitHub 컨테이너 레지스트리에서 이미지 가져오기
 docker pull ghcr.io/asyncfuncai/deepwiki-open:latest
- 
+
 # 환경 변수와 함께 컨테이너 실행
 docker run -p 8001:8001 -p 3000:3000 \
   -e GOOGLE_API_KEY=your_google_api_key \
@@ -212,59 +212,59 @@ docker run -p 8001:8001 -p 3000:3000 \
   -v ~/.adalflow:/root/.adalflow \
   ghcr.io/asyncfuncai/deepwiki-open:latest
 ```
- 
+
 이 명령어는 또한 호스트의 `~/.adalflow`를 컨테이너의 `/root/.adalflow`에 마운트합니다. 이 경로는 다음을 저장하는 데 사용됩니다:
 - 복제된 저장소 (`~/.adalflow/repos/`)
 - 해당 저장소의 임베딩 및 인덱스 (`~/.adalflow/databases/`)
 - 생성된 위키의 캐시 (`~/.adalflow/wikicache/`)
 
 이를 통해 컨테이너가 중지되거나 제거되어도 데이터가 유지됩니다.
- 
+
 또는 제공된 `docker-compose.yml` 파일을 사용하세요:
- 
+
 ```bash
 # API 키가 포함된 .env 파일을 먼저 편집
 docker-compose up
 ```
- 
+
 (`docker-compose.yml` 파일은 위의 `docker run` 명령어와 유사하게 데이터 지속성을 위해 `~/.adalflow`를 마운트하도록 미리 구성되어 있습니다.)
- 
+
 #### Docker에서 .env 파일 사용하기
- 
+
 .env 파일을 컨테이너에 마운트할 수도 있습니다:
- 
+
 ```bash
 # API 키가 포함된 .env 파일 생성
 echo "GOOGLE_API_KEY=your_google_api_key" > .env
 echo "OPENAI_API_KEY=your_openai_api_key" >> .env
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" >> .env
- 
+
 # .env 파일을 마운트하여 컨테이너 실행
 docker run -p 8001:8001 -p 3000:3000 \
   -v $(pwd)/.env:/app/.env \
   -v ~/.adalflow:/root/.adalflow \
   ghcr.io/asyncfuncai/deepwiki-open:latest
 ```
- 
+
 이 명령어는 또한 호스트의 `~/.adalflow`를 컨테이너의 `/root/.adalflow`에 마운트합니다. 이 경로는 다음을 저장하는 데 사용됩니다:
 - 복제된 저장소 (`~/.adalflow/repos/`)
 - 해당 저장소의 임베딩 및 인덱스 (`~/.adalflow/databases/`)
 - 생성된 위키의 캐시 (`~/.adalflow/wikicache/`)
 
 이를 통해 컨테이너가 중지되거나 제거되어도 데이터가 유지됩니다.
- 
+
 #### 로컬에서 Docker 이미지 빌드하기
- 
+
 로컬에서 Docker 이미지를 빌드하려면:
- 
+
 ```bash
 # 저장소 클론
 git clone https://github.com/AsyncFuncAI/deepwiki-open.git
 cd deepwiki-open
- 
+
 # Docker 이미지 빌드
 docker build -t deepwiki-open .
- 
+
 # 컨테이너 실행
 docker run -p 8001:8001 -p 3000:3000 \
   -e GOOGLE_API_KEY=your_google_api_key \
@@ -272,16 +272,16 @@ docker run -p 8001:8001 -p 3000:3000 \
   -e OPENROUTER_API_KEY=your_openrouter_api_key \
   deepwiki-open
 ```
- 
+
 ### API 서버 상세 정보
- 
+
 API 서버는 다음을 제공합니다:
 - 저장소 복제 및 인덱싱
 - RAG (Retrieval Augmented Generation)
 - 스트리밍 채팅 완성
- 
+
 자세한 내용은 [API README](./api/README.md)를 참조하세요.
- 
+
 ## 🤖 제공자 기반 모델 선택 시스템
 
 DeepWiki는 이제 여러 LLM 제공자를 지원하는 유연한 제공자 기반 모델 선택 시스템을 구현했습니다:
@@ -304,7 +304,7 @@ OPENAI_API_KEY=귀하의_OpenAI_키         # OpenAI 모델에 필요
 OPENROUTER_API_KEY=귀하의_OpenRouter_키 # OpenRouter 모델에 필요
 
 # OpenAI API 기본 URL 구성
-OPENAI_API_BASE=https://사용자정의_API_엔드포인트.com/v1  # 선택 사항, 사용자 정의 OpenAI API 엔드포인트용
+OPENAI_BASE_URL=https://사용자정의_API_엔드포인트.com/v1  # 선택 사항, 사용자 정의 OpenAI API 엔드포인트용
 ```
 
 ### 서비스 제공자를 위한 사용자 정의 모델 선택
@@ -328,42 +328,42 @@ OpenAI 클라이언트의 base_url 구성은 주로 비공개 API 채널이 있�
 **출시 예정**: 향후 업데이트에서 DeepWiki는 사용자가 요청에서 자신의 API 키를 제공해야 하는 모드를 지원할 예정입니다. 이를 통해 비공개 채널이 있는 기업 고객은 DeepWiki 배포와 자격 증명을 공유하지 않고도 기존 API 구성을 사용할 수 있습니다.
 
 ## 🔌 OpenRouter 통합
- 
+
 DeepWiki는 이제 [OpenRouter](https://openrouter.ai/)를 모델 제공자로 지원하여, 단일 API를 통해 수백 개의 AI 모델에 접근할 수 있습니다:
- 
+
 - **다양한 모델 옵션**: OpenAI, Anthropic, Google, Meta, Mistral 등 다양한 모델 이용 가능
 - **간편한 설정**: OpenRouter API 키만 추가하고 원하는 모델 선택
 - **비용 효율성**: 예산과 성능에 맞는 모델 선택 가능
 - **손쉬운 전환**: 코드 변경 없이 다양한 모델 간 전환 가능
- 
+
 ### DeepWiki에서 OpenRouter 사용법
- 
+
 1. **API 키 받기**: [OpenRouter](https://openrouter.ai/) 가입 후 API 키 획득
 2. **환경 변수 추가**: `.env` 파일에 `OPENROUTER_API_KEY=your_key` 추가
 3. **UI에서 활성화**: 홈페이지에서 "Use OpenRouter API" 옵션 체크
 4. **모델 선택**: GPT-4o, Claude 3.5 Sonnet, Gemini 2.0 등 인기 모델 선택
- 
+
 OpenRouter는 특히 다음과 같은 경우 유용합니다:
 - 여러 서비스에 가입하지 않고 다양한 모델 시도
 - 지역 제한이 있는 모델 접근
 - 모델 제공자별 성능 비교
 - 비용과 성능 최적화
- 
+
 ## 🤖 Ask 및 DeepResearch 기능
- 
+
 ### Ask 기능
- 
+
 Ask 기능은 Retrieval Augmented Generation (RAG)을 사용해 저장소와 대화할 수 있습니다:
- 
+
 - **문맥 인지 답변**: 저장소 내 실제 코드 기반으로 정확한 답변 제공
 - **RAG 기반**: 관련 코드 조각을 검색해 근거 있는 답변 생성
 - **실시간 스트리밍**: 답변 생성 과정을 실시간으로 확인 가능
 - **대화 기록 유지**: 질문 간 문맥을 유지해 더 일관된 대화 가능
- 
+
 ### DeepResearch 기능
- 
+
 DeepResearch는 다중 턴 연구 프로세스를 통해 저장소 분석을 한층 심화합니다:
- 
+
 - **심층 조사**: 여러 연구 반복을 통해 복잡한 주제 철저히 탐구
 - **구조화된 프로세스**: 연구 계획, 업데이트, 최종 결론 단계로 진행
 - **자동 연속 진행**: AI가 최대 5회 반복해 연구를 계속 진행
@@ -371,59 +371,59 @@ DeepResearch는 다중 턴 연구 프로세스를 통해 저장소 분석을 한
   1. **연구 계획**: 접근법과 초기 발견 사항 개요 작성
   2. **연구 업데이트**: 이전 반복 내용을 바탕으로 새로운 통찰 추가
   3. **최종 결론**: 모든 반복을 종합한 포괄적 답변 제공
- 
+
 DeepResearch를 사용하려면 질문 제출 전 Ask 인터페이스에서 "Deep Research" 스위치를 켜세요.
- 
+
 ## 📱 스크린샷
- 
+
 ![DeepWiki Main Interface](screenshots/Interface.png)
 *DeepWiki의 메인 인터페이스*
- 
+
 ![Private Repository Support](screenshots/privaterepo.png)
 *개인 액세스 토큰으로 비공개 저장소 접근*
- 
+
 ![DeepResearch Feature](screenshots/DeepResearch.png)
 *DeepResearch는 복잡한 주제에 대해 다중 턴 조사를 수행*
- 
+
 ### 데모 영상
- 
+
 [![DeepWiki Demo Video](https://img.youtube.com/vi/zGANs8US8B4/0.jpg)](https://youtu.be/zGANs8US8B4)
- 
+
 *DeepWiki 작동 영상 보기!*
- 
+
 ## ❓ 문제 해결
- 
+
 ### API 키 문제
 - **"환경 변수 누락"**: `.env` 파일이 프로젝트 루트에 있고 필요한 API 키가 포함되어 있는지 확인
 - **"API 키가 유효하지 않음"**: 키를 정확히 복사했는지, 공백이 없는지 확인
 - **"OpenRouter API 오류"**: OpenRouter API 키가 유효하고 충분한 크레딧이 있는지 확인
- 
+
 ### 연결 문제
 - **"API 서버에 연결할 수 없음"**: API 서버가 포트 8001에서 실행 중인지 확인
 - **"CORS 오류"**: API가 모든 출처를 허용하도록 설정되어 있지만 문제가 있으면 프론트엔드와 백엔드를 같은 머신에서 실행해 보세요
- 
+
 ### 생성 문제
 - **"위키 생성 오류"**: 아주 큰 저장소는 먼저 작은 저장소로 시도해 보세요
 - **"잘못된 저장소 형식"**: 유효한 GitHub, GitLab 또는 Bitbucket URL 형식인지 확인
 - **"저장소 구조를 가져올 수 없음"**: 비공개 저장소라면 적절한 권한의 개인 액세스 토큰을 입력했는지 확인
 - **"다이어그램 렌더링 오류"**: 앱이 자동으로 다이어그램 오류를 수정하려 시도합니다
- 
+
 ### 일반적인 해결법
 1. **서버 둘 다 재시작**: 간단한 재시작으로 대부분 문제 해결
 2. **콘솔 로그 확인**: 브라우저 개발자 도구에서 자바스크립트 오류 확인
 3. **API 로그 확인**: API 실행 터미널에서 Python 오류 확인
- 
+
 ## 🤝 기여
- 
+
 기여를 환영합니다! 다음을 자유롭게 해주세요:
 - 버그나 기능 요청을 위한 이슈 열기
 - 코드 개선을 위한 풀 리퀘스트 제출
 - 피드백과 아이디어 공유
- 
+
 ## 📄 라이선스
- 
+
 이 프로젝트는 MIT 라이선스 하에 있습니다 - 자세한 내용은 [LICENSE](LICENSE) 파일 참고.
- 
+
 ## ⭐ 스타 히스토리
- 
+
 [![Star History Chart](https://api.star-history.com/svg?repos=AsyncFuncAI/deepwiki-open&type=Date)](https://star-history.com/#AsyncFuncAI/deepwiki-open&Date)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ OPENAI_API_KEY=your_openai_api_key        # Required for OpenAI models
 OPENROUTER_API_KEY=your_openrouter_api_key # Required for OpenRouter models
 
 # OpenAI API Base URL Configuration
-OPENAI_API_BASE=https://custom-api-endpoint.com/v1  # Optional, for custom OpenAI API endpoints
+OPENAI_BASE_URL=https://custom-api-endpoint.com/v1  # Optional, for custom OpenAI API endpoints
 
 # Configuration Directory
 DEEPWIKI_CONFIG_DIR=/path/to/custom/config/dir  # Optional, for custom config file location

--- a/README.vi.md
+++ b/README.vi.md
@@ -99,12 +99,12 @@ yarn dev
 DeepWiki dùng AI để:
 
 1. Clone và phân tích GitHub, GitLab, hoặc Bitbucket repository (bao gồm private repos với token authentication)
-2. Tạo embeddings cho code (Rag support) 
+2. Tạo embeddings cho code (Rag support)
 3. Tạo documentation với context-aware AI (dùng Google Gemini, OpenAI, OpenRouter, hay local Ollama models)
 4. Tạo diagrams để giải thích code relationships
 5. Organize thông tin thành 1 trang wiki
-6. Cho phép Q&A với repository 
-7. Cung cấp khả năng DeepResearch 
+6. Cho phép Q&A với repository
+7. Cung cấp khả năng DeepResearch
 
 ```mermaid
 graph TD
@@ -147,8 +147,8 @@ graph TD
 ```
 deepwiki/
 ├── api/                  # Backend API server
-│   ├── main.py           # API 
-│   ├── api.py            # FastAPI 
+│   ├── main.py           # API
+│   ├── api.py            # FastAPI
 │   ├── rag.py            # Retrieval Augmented Generation (RAG)
 │   ├── data_pipeline.py  # Data processing utilities
 │   └── requirements.txt  # Python dependencies
@@ -176,7 +176,7 @@ deepwiki/
 | `PORT` | Port của API server (mặc định: 8001) | không | Nếu bạn muốn chạy API và frontend trên cùng 1 máy, hãy điều chỉnh Port `SERVER_BASE_URL` |
 | `SERVER_BASE_URL` | Đường dẫnn mặt định của API server (mặc định: http://localhost:8001) | không |
 
-### Cài Đặt với Docker 
+### Cài Đặt với Docker
 
 Bạn có thể dùng Docker để run DeepWiki:
 
@@ -210,14 +210,14 @@ echo "GOOGLE_API_KEY=your_google_api_key" > .env
 echo "OPENAI_API_KEY=your_openai_api_key" >> .env
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" >> .env
 
-# Run container với .env file 
+# Run container với .env file
 docker run -p 8001:8001 -p 3000:3000 \
   -v $(pwd)/.env:/app/.env \
   -v ~/.adalflow:/root/.adalflow \
   ghcr.io/asyncfuncai/deepwiki-open:latest
 ```
 
-#### Bạn có thể Building the Docker image trên máy cục bộ 
+#### Bạn có thể Building the Docker image trên máy cục bộ
 
 
 ```bash
@@ -236,7 +236,7 @@ docker run -p 8001:8001 -p 3000:3000 \
   deepwiki-open
 ```
 
-### Chi tiết API Server 
+### Chi tiết API Server
 
 API server cung cấp:
 - Repository cloning và indexing
@@ -267,7 +267,7 @@ OPENAI_API_KEY=openai_key_của_bạn            # Bắt buộc cho các mô hì
 OPENROUTER_API_KEY=openrouter_key_của_bạn    # Bắt buộc cho các mô hình OpenRouter
 
 # Cấu hình URL cơ sở cho OpenAI API
-OPENAI_API_BASE=https://endpoint-tùy-chỉnh.com/v1  # Tùy chọn, cho các điểm cuối API OpenAI tùy chỉnh
+OPENAI_BASE_URL=https://endpoint-tùy-chỉnh.com/v1  # Tùy chọn, cho các điểm cuối API OpenAI tùy chỉnh
 
 # Thư mục cấu hình
 DEEPWIKI_CONFIG_DIR=/đường/dẫn/đến/thư_mục/cấu_hình  # Tùy chọn, cho vị trí tệp cấu hình tùy chỉnh
@@ -317,25 +317,25 @@ Cấu hình base_url của OpenAI Client được thiết kế chủ yếu cho n
 
 DeepWiki hiện đã hỗ trợ [OpenRouter](https://openrouter.ai/) làm nhà cung cấp mô hình, cho phép bạn truy cập hàng trăm mô hình AI thông qua một API duy nhất:
 
-- **Nhiều tùy chọn mô hình**: Truy cập các mô hình từ OpenAI, Anthropic, Google, Meta, Mistral và nhiều nhà cung cấp khác  
-- **Cấu hình đơn giản**: Chỉ cần thêm khóa API của bạn từ OpenRouter và chọn mô hình bạn muốn sử dụng  
-- **Tiết kiệm chi phí**: Lựa chọn mô hình phù hợp với ngân sách và nhu cầu hiệu suất của bạn  
+- **Nhiều tùy chọn mô hình**: Truy cập các mô hình từ OpenAI, Anthropic, Google, Meta, Mistral và nhiều nhà cung cấp khác
+- **Cấu hình đơn giản**: Chỉ cần thêm khóa API của bạn từ OpenRouter và chọn mô hình bạn muốn sử dụng
+- **Tiết kiệm chi phí**: Lựa chọn mô hình phù hợp với ngân sách và nhu cầu hiệu suất của bạn
 - **Chuyển đổi dễ dàng**: Chuyển đổi giữa các mô hình khác nhau mà không cần thay đổi mã nguồn
 
 
 ### Cách sử dụng OpenRouter với DeepWiki
 
-1. **Lấy API Key**: Đăng ký tại [OpenRouter](https://openrouter.ai/) và lấy khóa API 
-2. **Thêm vào biến môi trường**: Thêm `OPENROUTER_API_KEY=your_key` vào file `.env` 
-3. **Bật trong giao diện**: Chọn "Use OpenRouter API" trên trang chủ  
+1. **Lấy API Key**: Đăng ký tại [OpenRouter](https://openrouter.ai/) và lấy khóa API
+2. **Thêm vào biến môi trường**: Thêm `OPENROUTER_API_KEY=your_key` vào file `.env`
+3. **Bật trong giao diện**: Chọn "Use OpenRouter API" trên trang chủ
 4. **Chọn mô hình**: Lựa chọn từ các mô hình phổ biến như GPT-4o, Claude 3.5 Sonnet, Gemini 2.0 và nhiều hơn nữa
 
 
 OpenRouter đặc biệt hữu ích nếu bạn muốn:
 
-- Thử nhiều mô hình khác nhau mà không cần đăng ký nhiều dịch vụ  
-- Truy cập các mô hình có thể bị giới hạn tại khu vực của bạn  
-- So sánh hiệu năng giữa các nhà cung cấp mô hình khác nhau  
+- Thử nhiều mô hình khác nhau mà không cần đăng ký nhiều dịch vụ
+- Truy cập các mô hình có thể bị giới hạn tại khu vực của bạn
+- So sánh hiệu năng giữa các nhà cung cấp mô hình khác nhau
 - Tối ưu hóa chi phí so với hiệu suất dựa trên nhu cầu của bạn
 
 
@@ -345,9 +345,9 @@ OpenRouter đặc biệt hữu ích nếu bạn muốn:
 
 Tính năng Hỏi cho phép bạn trò chuyện với kho mã của mình bằng cách sử dụng kỹ thuật RAG (Retrieval Augmented Generation):
 
-- **Phản hồi theo ngữ cảnh**: Nhận câu trả lời chính xác dựa trên mã thực tế trong kho của bạn  
-- **Ứng dụng RAG**: Hệ thống truy xuất các đoạn mã liên quan để tạo ra câu trả lời có cơ sở  
-- **Phản hồi theo thởi gian thực**: Xem câu trả lời được tạo ra trực tiếp, mang lại trải nghiệm tương tác hơn  
+- **Phản hồi theo ngữ cảnh**: Nhận câu trả lời chính xác dựa trên mã thực tế trong kho của bạn
+- **Ứng dụng RAG**: Hệ thống truy xuất các đoạn mã liên quan để tạo ra câu trả lời có cơ sở
+- **Phản hồi theo thởi gian thực**: Xem câu trả lời được tạo ra trực tiếp, mang lại trải nghiệm tương tác hơn
 - **Lưu lịch sử cuộc trò chuyện**: Hệ thống duy trì ngữ cảnh giữa các câu hỏi để cuộc đối thoại liền mạch hơn
 
 
@@ -355,12 +355,12 @@ Tính năng Hỏi cho phép bạn trò chuyện với kho mã của mình bằng
 
 DeepResearch nâng tầm phân tích kho mã với quy trình nghiện cứu nhiểu vòng:
 
-- **Ngieen cứu chuyên sâu**: Khám phá kỹ lưỡng các chủ đề phức tạp thông qua nhiểu vòng nghiện cứu  
-- **Quy trình có cấu trúc**: Tuân theo kế hoạch nghiện cứu rõ ràng với các bản cập nhật và kết luận tổng thể  
-- **Tự động tiếp tục**: AI sẽ tự động tiếp tục quá trình nghiện cứu cho đến khi đưa ra kết luận (tối đa 5 vòng)  
-- **Các giai đoạn nghiện cứu**:  
-  1. **Kế hoạch nghiện cứu**: Phác thảo phương pháp và những phát hiện ban đầu  
-  2. **Cập nhật nghiện cứu**: Bổ sung kiến thức mới qua từng vòng lặp  
+- **Ngieen cứu chuyên sâu**: Khám phá kỹ lưỡng các chủ đề phức tạp thông qua nhiểu vòng nghiện cứu
+- **Quy trình có cấu trúc**: Tuân theo kế hoạch nghiện cứu rõ ràng với các bản cập nhật và kết luận tổng thể
+- **Tự động tiếp tục**: AI sẽ tự động tiếp tục quá trình nghiện cứu cho đến khi đưa ra kết luận (tối đa 5 vòng)
+- **Các giai đoạn nghiện cứu**:
+  1. **Kế hoạch nghiện cứu**: Phác thảo phương pháp và những phát hiện ban đầu
+  2. **Cập nhật nghiện cứu**: Bổ sung kiến thức mới qua từng vòng lặp
   3. **Kết luận cuối cùng**: Đưa ra câu trả lời toàn diện dựa trên tất cả các vòng nghiện cứu
 
 Để sử dụng DeepResearch, chỉ cần bật công tắc "Deep Research" trong giao diện Hỏi (Ask) trước khi gửi câu hỏi của bạn.
@@ -368,13 +368,13 @@ DeepResearch nâng tầm phân tích kho mã với quy trình nghiện cứu nhi
 
 ## 📱 Ảnh chụp màng hình
 
-![Giao diện chính của DeepWiki](screenshots/Interface.png)  
+![Giao diện chính của DeepWiki](screenshots/Interface.png)
 *Giao diện chính của DeepWiki*
 
-![Hỗ trợ kho riêng tư](screenshots/privaterepo.png)  
+![Hỗ trợ kho riêng tư](screenshots/privaterepo.png)
 *Truy cập kho riêng tư bằng Personal Access Token*
 
-![Tính năng DeepResearch](screenshots/DeepResearch.png)  
+![Tính năng DeepResearch](screenshots/DeepResearch.png)
 *DeepResearch thực hiện nghiện cứu nhiểu vòng cho các chủ đề phức tạp*
 
 ### Demo Video
@@ -386,31 +386,31 @@ DeepResearch nâng tầm phân tích kho mã với quy trình nghiện cứu nhi
 ## ❓ Khắc phục sự cố
 
 ### Vấn đề với API Key
-- **"Thiếu biến môi trường"**: Đảm bảo rằng file `.env` của bạn nằm ở thư mục gốc của dự án và chứa các API key cần thiết  
-- **"API key không hợp lệ"**: Kiểm tra lại xem bạn đã sao chép đầy đủ API key mà không có khoảng trắng thừa chưa  
+- **"Thiếu biến môi trường"**: Đảm bảo rằng file `.env` của bạn nằm ở thư mục gốc của dự án và chứa các API key cần thiết
+- **"API key không hợp lệ"**: Kiểm tra lại xem bạn đã sao chép đầy đủ API key mà không có khoảng trắng thừa chưa
 - **"Lỗi API OpenRouter"**: Xác minh rằng API key của OpenRouter là hợp lệ và có đủ tín dụng
 
 ### Vấn đề kết nối
-- **"Không thể kết nối với máy chủ API"**: Đảm bảo máy chủ API đang chạy trên cổng 8001  
+- **"Không thể kết nối với máy chủ API"**: Đảm bảo máy chủ API đang chạy trên cổng 8001
 - **"Lỗi CORS"**: API được cấu hình để cho phép tất cả các nguồn gốc, nhưng nếu gặp sự cố, thử chạy cả frontend và backend trên cùng một máy tính
 
 ### Vấn đề khi tạo nội dung
-- **"Lỗi khi tạo wiki"**: Với các kho mã rất lớn, hãy thử trước với kho mã nhỏ hơn  
-- **"Định dạng kho mã không hợp lệ"**: Đảm bảo bạn đang sử dụng định dạng URL hợp lệ cho GitHub, GitLab hoặc Bitbucket  
-- **"Không thể lấy cấu trúc kho mã"**: Với các kho mã riêng tư, hãy đảm bảo bạn đã nhập token truy cập cá nhân hợp lệ và có quyền truy cập phù hợp  
+- **"Lỗi khi tạo wiki"**: Với các kho mã rất lớn, hãy thử trước với kho mã nhỏ hơn
+- **"Định dạng kho mã không hợp lệ"**: Đảm bảo bạn đang sử dụng định dạng URL hợp lệ cho GitHub, GitLab hoặc Bitbucket
+- **"Không thể lấy cấu trúc kho mã"**: Với các kho mã riêng tư, hãy đảm bảo bạn đã nhập token truy cập cá nhân hợp lệ và có quyền truy cập phù hợp
 - **"Lỗi khi render sơ đồ"**: Ứng dụng sẽ tự động thử khắc phục các sơ đồ bị lỗi
 
 ### Các giải pháp phổ biến
-1. **Khởi động lại cả hai máy chủ**: Đôi khi, một lần khởi động lại đơn giản có thể giải quyết hầu hết các vấn đề  
-2. **Kiểm tra nhật ký trình duyệt**: Mở công cụ phát triển của trình duyệt để xem các lỗi JavaScript  
+1. **Khởi động lại cả hai máy chủ**: Đôi khi, một lần khởi động lại đơn giản có thể giải quyết hầu hết các vấn đề
+2. **Kiểm tra nhật ký trình duyệt**: Mở công cụ phát triển của trình duyệt để xem các lỗi JavaScript
 3. **Kiểm tra nhật ký API**: Xem các lỗi Python trong terminal nơi API đang chạy
 
 
 ## 🤝 Đóng góp
 
 Chúng tôi hoan nghênh mọi đóng góp! Bạn có thể:
-- Mở các vấn đề (issues) để báo lỗi hoặc yêu cầu tính năng  
-- Gửi pull request để cải thiện mã nguồn  
+- Mở các vấn đề (issues) để báo lỗi hoặc yêu cầu tính năng
+- Gửi pull request để cải thiện mã nguồn
 - Chia sẻ phản hồi và ý tưởng của bạn
 
 ## 📄 Giấy phép

--- a/README.zh.md
+++ b/README.zh.md
@@ -272,7 +272,7 @@ OPENAI_API_KEY=你的OpenAI密钥        # 使用 OpenAI 模型必需
 OPENROUTER_API_KEY=你的OpenRouter密钥 # 使用 OpenRouter 模型必需
 
 # OpenAI API 基础 URL 配置
-OPENAI_API_BASE=https://自定义API端点.com/v1  # 可选，用于自定义 OpenAI API 端点
+OPENAI_BASE_URL=https://自定义API端点.com/v1  # 可选，用于自定义 OpenAI API 端点
 ```
 
 ### 为服务提供者设计的自定义模型选择
@@ -306,7 +306,7 @@ OPENAI_API_KEY=your_openai_api_key        # OpenAI模型必需
 OPENROUTER_API_KEY=your_openrouter_api_key # OpenRouter模型必需
 
 # OpenAI API基础URL配置
-OPENAI_API_BASE=https://custom-api-endpoint.com/v1  # 可选，用于自定义OpenAI API端点
+OPENAI_BASE_URL=https://custom-api-endpoint.com/v1  # 可选，用于自定义OpenAI API端点
 
 # 配置目录
 DEEPWIKI_CONFIG_DIR=/path/to/custom/config/dir  # 可选，用于自定义配置文件位置

--- a/api/README.md
+++ b/api/README.md
@@ -32,7 +32,7 @@ OPENAI_API_KEY=your_openai_api_key        # Required for embeddings and OpenAI m
 OPENROUTER_API_KEY=your_openrouter_api_key  # Required only if using OpenRouter models
 
 # OpenAI API Configuration
-OPENAI_API_BASE=https://custom-api-endpoint.com/v1  # Optional, for custom OpenAI API endpoints
+OPENAI_BASE_URL=https://custom-api-endpoint.com/v1  # Optional, for custom OpenAI API endpoints
 
 # Server Configuration
 PORT=8001  # Optional, defaults to 8001
@@ -56,7 +56,7 @@ DeepWiki supports multiple LLM providers. The environment variables above are re
 - **Ollama**: No API key required (runs locally)
 
 ##### Custom OpenAI API Endpoints
-The `OPENAI_API_BASE` variable allows you to specify a custom endpoint for the OpenAI API. This is useful for:
+The `OPENAI_BASE_URL` variable allows you to specify a custom endpoint for the OpenAI API. This is useful for:
 
 - Enterprise users with private API channels
 - Organizations using self-hosted or custom-deployed LLM services
@@ -64,7 +64,7 @@ The `OPENAI_API_BASE` variable allows you to specify a custom endpoint for the O
 
 **Example:** you can use the endpoint which support the OpenAI protocol provided by any organization
 ```
-OPENAI_API_BASE=https://custom-openai-endpoint.com/v1
+OPENAI_BASE_URL=https://custom-openai-endpoint.com/v1
 ```
 
 ##### Configuration Files
@@ -83,7 +83,7 @@ DeepWiki now uses JSON configuration files to manage various system components i
    - Specifies text splitter settings for document chunking
 
 3. **`repo.json`**: Configuration for repository handling
-   - Located in `api/config/` by default 
+   - Located in `api/config/` by default
    - Contains file filters to exclude certain files and directories
    - Defines repository size limits and processing rules
 

--- a/api/openai_client.py
+++ b/api/openai_client.py
@@ -164,7 +164,7 @@ class OpenAIClient(ModelClient):
         chat_completion_parser: Callable[[Completion], Any] = None,
         input_type: Literal["text", "messages"] = "text",
         base_url: Optional[str] = None,
-        env_base_url_name: str = "OPENAI_API_BASE",
+        env_base_url_name: str = "OPENAI_BASE_URL",
         env_api_key_name: str = "OPENAI_API_KEY",
     ):
         r"""It is recommended to set the OPENAI_API_KEY environment variable instead of passing it as an argument.
@@ -426,10 +426,10 @@ class OpenAIClient(ModelClient):
                 # Make a copy of api_kwargs to avoid modifying the original
                 streaming_kwargs = api_kwargs.copy()
                 streaming_kwargs["stream"] = True
-                
+
                 # Get streaming response
                 stream_response = self.sync_client.chat.completions.create(**streaming_kwargs)
-                
+
                 # Accumulate all content from the stream
                 accumulated_content = ""
                 id = ""


### PR DESCRIPTION
It took me forever to debug and finally realise from this error:
```
2025-05-23 11:27:18,232 - adalflow.core.embedder - ERROR - Error calling the model: Error code: 401 - {'error': {'message': 'Your authentication token is not from a valid issuer.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_issuer'}}

Batch embedding documents: 100%|█| 2/2 [00:04<00:00,  1.
Batch embedding documents: 100%|█| 2/2 [00:04<00:00,  2.
```

The OpenAI environment variable should be `OPENAI_BASE_URL` and `OPENAI_API_KEY` which are recognised by the OpenAI client. It is used inconsistently here with `OPENAI_API_KEY` and `OPENAI_API_BASE` .