### PR TITLE
feat: Implement authorization mode for wiki generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,24 @@ The OpenAI Client's base_url configuration is designed primarily for enterprise 
 | `GOOGLE_API_KEY` | Google Gemini API key for AI generation | No | Required only if you want to use Google Gemini models
 | `OPENAI_API_KEY` | OpenAI API key for embeddings | Yes | Note: This is required even if you're not using OpenAI models, as it's used for embeddings. |
 | `OPENROUTER_API_KEY` | OpenRouter API key for alternative models | No | Required only if you want to use OpenRouter models |
+| `DEEPWIKI_AUTH_MODE` | Set to `true` or `1` to enable authorization mode. | No | Defaults to `false`. If enabled, `DEEPWIKI_AUTH_CODE` is required. |
+| `DEEPWIKI_AUTH_CODE` | The secret code required for wiki generation when `DEEPWIKI_AUTH_MODE` is enabled. | No | Only used if `DEEPWIKI_AUTH_MODE` is `true` or `1`. |
 | `PORT` | Port for the API server (default: 8001) | No | If you host API and frontend on the same machine, make sure change port of `SERVER_BASE_URL` accordingly |
 | `SERVER_BASE_URL` | Base URL for the API server (default: http://localhost:8001) | No |
 
 If you're not using ollama mode, you need to configure an OpenAI API key for embeddings. Other API keys are only required when configuring and using models from the corresponding providers.
+
+## Authorization Mode
+
+DeepWiki can be configured to run in an authorization mode, where wiki generation requires a valid authorization code. This is useful if you want to control who can use the generation feature.
+Restricts frontend initiation and protects cache deletion, but doesn't fully prevent backend generation if API endpoints are hit directly.
+
+To enable authorization mode, set the following environment variables:
+
+- `DEEPWIKI_AUTH_MODE`: Set this to `true` or `1`. When enabled, the frontend will display an input field for the authorization code.
+- `DEEPWIKI_AUTH_CODE`: Set this to the desired secret code. Restricts frontend initiation and protects cache deletion, but doesn't fully prevent backend generation if API endpoints are hit directly.
+
+If `DEEPWIKI_AUTH_MODE` is not set or is set to `false` (or any other value than `true`/`1`), the authorization feature will be disabled, and no code will be required.
 
 ### Docker Setup
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -310,8 +310,24 @@ OPENAI_BASE_URL=https://custom-api-endpoint.com/v1  # 可选，用于自定义Op
 
 # 配置目录
 DEEPWIKI_CONFIG_DIR=/path/to/custom/config/dir  # 可选，用于自定义配置文件位置
+
+# 授权模式
+DEEPWIKI_AUTH_MODE=true  # 设置为 true 或 1 以启用授权模式
+DEEPWIKI_AUTH_CODE=your_secret_code # 当 DEEPWIKI_AUTH_MODE 启用时所需的授权码
 ```
 如果不使用ollama模式，那么需要配置OpenAI API密钥用于embeddings。其他密钥只有配置并使用使用对应提供商的模型时才需要。
+
+## 授权模式
+
+DeepWiki 可以配置为在授权模式下运行，在该模式下，生成 Wiki 需要有效的授权码。如果您想控制谁可以使用生成功能，这将非常有用。
+限制使用前端页面生成wiki并保护已生成页面的缓存删除，但无法完全阻止直接访问 API 端点生成wiki。主要目的是为了保护管理员已生成的wiki页面，防止被访问者重新生成。
+
+要启用授权模式，请设置以下环境变量：
+
+- `DEEPWIKI_AUTH_MODE`: 将此设置为 `true` 或 `1`。启用后，前端将显示一个用于输入授权码的字段。
+- `DEEPWIKI_AUTH_CODE`: 将此设置为所需的密钥。限制使用前端页面生成wiki并保护已生成页面的缓存删除，但无法完全阻止直接访问 API 端点生成wiki。
+
+如果未设置 `DEEPWIKI_AUTH_MODE` 或将其设置为 `false`（或除 `true`/`1` 之外的任何其他值），则授权功能将被禁用，并且不需要任何代码。
 
 ### 配置文件
 

--- a/api/api.py
+++ b/api/api.py
@@ -121,7 +121,24 @@ class ModelConfig(BaseModel):
     providers: List[Provider] = Field(..., description="List of available model providers")
     defaultProvider: str = Field(..., description="ID of the default provider")
 
-from api.config import configs
+class AuthorizationConfig(BaseModel):
+    code: str = Field(..., description="Authorization code")
+
+from api.config import configs, WIKI_AUTH_MODE, WIKI_AUTH_CODE
+
+@app.get("/auth/status")
+async def get_auth_status():
+    """
+    Check if authentication is required for the wiki.
+    """
+    return {"auth_required": WIKI_AUTH_MODE}
+
+@app.post("/auth/validate")
+async def validate_auth_code(request: AuthorizationConfig):
+    """
+    Check authorization code.
+    """
+    return {"success": WIKI_AUTH_CODE == request.code}
 
 @app.get("/models/config", response_model=ModelConfig)
 async def get_model_config():
@@ -451,11 +468,17 @@ async def delete_wiki_cache(
     owner: str = Query(..., description="Repository owner"),
     repo: str = Query(..., description="Repository name"),
     repo_type: str = Query(..., description="Repository type (e.g., github, gitlab)"),
-    language: str = Query(..., description="Language of the wiki content")
+    language: str = Query(..., description="Language of the wiki content"),
+    authorization_code: str = Query(..., description="Authorization code")
 ):
     """
     Deletes a specific wiki cache from the file system.
     """
+    if WIKI_AUTH_MODE:
+        logger.info("check the authorization code")
+        if WIKI_AUTH_CODE != authorization_code:
+            raise HTTPException(status_code=401, detail="Authorization code is invalid")
+
     logger.info(f"Attempting to delete wiki cache for {owner}/{repo} ({repo_type}), lang: {language}")
     cache_path = get_wiki_cache_path(owner, repo, repo_type, language)
 
@@ -485,7 +508,9 @@ async def root():
             "Wiki": [
                 "POST /export/wiki - Export wiki content as Markdown or JSON",
                 "GET /api/wiki_cache - Retrieve cached wiki data",
-                "POST /api/wiki_cache - Store wiki data to cache"
+                "POST /api/wiki_cache - Store wiki data to cache",
+                "GET /auth/status - Check if wiki authentication is enabled",
+                "POST /auth/validate - Check if wiki authentication is valid"
             ],
             "LocalRepo": [
                 "GET /local_repo/structure - Get structure of a local repository (with path parameter)",

--- a/api/config.py
+++ b/api/config.py
@@ -23,6 +23,11 @@ if GOOGLE_API_KEY:
 if OPENROUTER_API_KEY:
     os.environ["OPENROUTER_API_KEY"] = OPENROUTER_API_KEY
 
+# Wiki authentication settings
+raw_auth_mode = os.environ.get('DEEPWIKI_AUTH_MODE', 'False')
+WIKI_AUTH_MODE = raw_auth_mode.lower() in ['true', '1', 't']
+WIKI_AUTH_CODE = os.environ.get('DEEPWIKI_AUTH_CODE', '')
+
 # Get configuration directory from environment variable, or use default if not set
 CONFIG_DIR = os.environ.get('DEEPWIKI_CONFIG_DIR', None)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,14 @@ const nextConfig: NextConfig = {
         source: '/local_repo/structure',
         destination: `${TARGET_SERVER_BASE_URL}/local_repo/structure`,
       },
+      {
+        source: '/api/auth/status',
+        destination: `${TARGET_SERVER_BASE_URL}/auth/status`,
+      },
+      {
+        source: '/api/auth/validate',
+        destination: `${TARGET_SERVER_BASE_URL}/auth/validate`,
+      },
     ];
   },
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,10 +93,38 @@ export default function Home() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedLanguage, setSelectedLanguage] = useState<string>(language);
 
+  // Authentication state
+  const [authRequired, setAuthRequired] = useState<boolean>(false);
+  const [authCode, setAuthCode] = useState<string>('');
+  const [isAuthLoading, setIsAuthLoading] = useState<boolean>(true);
+
   // Sync the language context with the selectedLanguage state
   useEffect(() => {
     setLanguage(selectedLanguage);
   }, [selectedLanguage, setLanguage]);
+
+  // Fetch authentication status on component mount
+  useEffect(() => {
+    const fetchAuthStatus = async () => {
+      try {
+        setIsAuthLoading(true);
+        const response = await fetch('/api/auth/status');
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        setAuthRequired(data.auth_required);
+      } catch (err) {
+        console.error("Failed to fetch auth status:", err);
+        // Assuming auth is required if fetch fails to avoid blocking UI for safety
+        setAuthRequired(true);
+      } finally {
+        setIsAuthLoading(false);
+      }
+    };
+
+    fetchAuthStatus();
+  }, []);
 
   // Parse repository URL/input and extract owner and repo
   const parseRepositoryInput = (input: string): {
@@ -178,7 +206,39 @@ export default function Home() {
     setIsConfigModalOpen(true);
   };
 
-  const handleGenerateWiki = () => {
+  const validateAuthCode = async () => {
+    try {
+      if(authRequired) {
+        if(!authCode) {
+          return false;
+        }
+        const response = await fetch('/api/auth/validate', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({'code': authCode})
+        });
+        if (!response.ok) {
+          return false;
+        }
+        const data = await response.json();
+        return data.success || false;
+      }
+    } catch {
+      return false;
+    }
+    return true;
+  };
+
+  const handleGenerateWiki = async () => {
+
+    // Check authorization code
+    const validation = await validateAuthCode();
+    if(!validation) {
+      throw new Error('Failed to validate the authorization code');
+    }
+
     // Prevent multiple submissions
     if (isSubmitting) {
       console.log('Form submission already in progress, ignoring duplicate click');
@@ -326,6 +386,10 @@ export default function Home() {
             setIncludedFiles={setIncludedFiles}
             onSubmit={handleGenerateWiki}
             isSubmitting={isSubmitting}
+            authRequired={authRequired}
+            authCode={authCode}
+            setAuthCode={setAuthCode}
+            isAuthLoading={isAuthLoading}
           />
 
         </div>

--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -824,6 +824,8 @@ const Ask: React.FC<AskProps> = ({
         onApply={() => {
           console.log('Model selection applied:', selectedProvider, selectedModel);
         }}
+        authRequired={false}
+        isAuthLoading={false}
       />
     </div>
   );

--- a/src/components/ConfigurationModal.tsx
+++ b/src/components/ConfigurationModal.tsx
@@ -49,6 +49,12 @@ interface ConfigurationModalProps {
   // Form submission
   onSubmit: () => void;
   isSubmitting: boolean;
+
+  // Authentication
+  authRequired?: boolean;
+  authCode?: string;
+  setAuthCode?: (code: string) => void;
+  isAuthLoading?: boolean;
 }
 
 export default function ConfigurationModal({
@@ -80,7 +86,11 @@ export default function ConfigurationModal({
   includedFiles,
   setIncludedFiles,
   onSubmit,
-  isSubmitting
+  isSubmitting,
+  authRequired,
+  authCode,
+  setAuthCode,
+  isAuthLoading
 }: ConfigurationModalProps) {
   const { messages: t } = useLanguage();
 
@@ -294,6 +304,36 @@ export default function ConfigurationModal({
                 </div>
               )}
             </div>
+
+            {/* Authorization Code Input */}
+            {isAuthLoading && (
+              <div className="mb-4 p-3 bg-[var(--background)]/50 rounded-md border border-[var(--border-color)] text-sm text-[var(--muted)]">
+                Loading authentication status...
+              </div>
+            )}
+            {!isAuthLoading && authRequired && (
+              <div className="mb-4 p-4 bg-[var(--background)]/50 rounded-md border border-[var(--border-color)]">
+                <label htmlFor="authCode" className="block text-sm font-medium text-[var(--foreground)] mb-2">
+                  {t.form?.authorizationCode || 'Authorization Code'}
+                </label>
+                <input
+                  type="password"
+                  id="authCode"
+                  value={authCode || ''}
+                  onChange={(e) => setAuthCode?.(e.target.value)}
+                  className="input-japanese block w-full px-3 py-2 text-sm rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)]"
+                  placeholder="Enter your authorization code"
+                />
+                 <div className="flex items-center mt-2 text-xs text-[var(--muted)]">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1 text-[var(--muted)]"
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                   {t.form?.authorizationRequired || 'Authentication is required to generate the wiki.'}
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Modal footer */}

--- a/src/components/ModelSelectionModal.tsx
+++ b/src/components/ModelSelectionModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { useLanguage } from '@/contexts/LanguageContext';
+import React, {useEffect, useState} from 'react';
+import {useLanguage} from '@/contexts/LanguageContext';
 import UserSelector from './UserSelector';
 import WikiTypeSelector from './WikiTypeSelector';
 
@@ -32,6 +32,11 @@ interface ModelSelectionModalProps {
   includedFiles?: string;
   setIncludedFiles?: (value: string) => void;
   showFileFilters?: boolean;
+  // Authentication
+  authRequired?: boolean;
+  authCode?: string;
+  setAuthCode?: (code: string) => void;
+  isAuthLoading?: boolean;
 }
 
 export default function ModelSelectionModal({
@@ -56,7 +61,11 @@ export default function ModelSelectionModal({
   setIncludedDirs,
   includedFiles = '',
   setIncludedFiles,
-  showFileFilters = false
+  showFileFilters = false,
+  authRequired = false,
+  authCode = '',
+  setAuthCode,
+  isAuthLoading,
 }: ModelSelectionModalProps) {
   const { messages: t } = useLanguage();
 
@@ -154,6 +163,35 @@ export default function ModelSelectionModal({
               includedFiles={localIncludedFiles}
               setIncludedFiles={showFileFilters ? (value: string) => setLocalIncludedFiles(value) : undefined}
             />
+            {/* Authorization Code Input */}
+            {isAuthLoading && (
+                <div className="mb-4 p-3 bg-[var(--background)]/50 rounded-md border border-[var(--border-color)] text-sm text-[var(--muted)]">
+                  Loading authentication status...
+                </div>
+            )}
+            {!isAuthLoading && authRequired && (
+                <div className="mb-4 p-4 bg-[var(--background)]/50 rounded-md border border-[var(--border-color)]">
+                  <label htmlFor="authCode" className="block text-sm font-medium text-[var(--foreground)] mb-2">
+                    {t.form?.authorizationCode || 'Authorization Code'}
+                  </label>
+                  <input
+                      type="password"
+                      id="authCode"
+                      value={authCode || ''}
+                      onChange={(e) => setAuthCode?.(e.target.value)}
+                      className="input-japanese block w-full px-3 py-2 text-sm rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)]"
+                      placeholder="Enter your authorization code"
+                  />
+                  <div className="flex items-center mt-2 text-xs text-[var(--muted)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1 text-[var(--muted)]"
+                         fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    {t.form?.authorizationRequired || 'Authentication is required to generate the wiki.'}
+                  </div>
+                </div>
+            )}
           </div>
 
           {/* Modal footer */}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -88,7 +88,9 @@
     "excludeMode": "Exclude Paths",
     "includeMode": "Include Only Paths",
     "excludeModeDescription": "Specify paths to exclude from processing (default behavior)",
-    "includeModeDescription": "Specify only the paths to include, ignoring all others"
+    "includeModeDescription": "Specify only the paths to include, ignoring all others",
+    "authorizationCode": "Authorization Code",
+    "authorizationRequired": "Authentication is required to generate the wiki."
   },
   "footer": {
     "copyright": "DeepWiki - AI-powered documentation for code repositories"

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -79,7 +79,9 @@
     "changeModel": "Cambiar Modelo",
     "defaultNote": "Estos valores predeterminados ya están aplicados. Agregue sus exclusiones personalizadas arriba.",
     "hideDefault": "Ocultar Predeterminados",
-    "viewDefault": "Ver Predeterminados"
+    "viewDefault": "Ver Predeterminados",
+    "authorizationCode": "Código de Autorización",
+    "authorizationRequired": "Generar Wiki requiere código de autorización"
   },
   "footer": {
     "copyright": "DeepWiki - Documentación impulsada por IA para repositorios de código"

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -79,7 +79,9 @@
     "changeModel": "モデルを変更",
     "defaultNote": "これらのデフォルト設定は既に適用されています。上記に追加の除外項目を入力してください。",
     "hideDefault": "デフォルトを隠す",
-    "viewDefault": "デフォルトを表示"
+    "viewDefault": "デフォルトを表示",
+    "authorizationCode": "認証コード",
+    "authorizationRequired": "Wiki生成には認証コードが必要です"
   },
   "footer": {
     "copyright": "DeepWiki - コードリポジトリのためのAI駆動ドキュメンテーション"

--- a/src/messages/kr.json
+++ b/src/messages/kr.json
@@ -79,7 +79,9 @@
       "changeModel": "모델 변경",
       "defaultNote": "이 기본 설정은 이미 적용되었습니다. 위에 사용자 지정 제외 항목을 추가하세요.",
       "hideDefault": "기본값 숨기기",
-      "viewDefault": "기본값 보기"
+      "viewDefault": "기본값 보기",
+      "authorizationCode": "인증코드",
+      "authorizationRequired": "Wiki 생성에는 인증코드가 필요합니다"
     },
     "footer": {
       "copyright": "DeepWiki - 코드 저장소를 위한 AI 기반 문서화"

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -79,7 +79,9 @@
     "changeModel": "Thay đổi mô hình",
     "defaultNote": "Các giá trị mặc định này đã được áp dụng. Thêm các loại trừ tùy chỉnh của bạn ở trên.",
     "hideDefault": "Ẩn mặc định",
-    "viewDefault": "Xem mặc định"
+    "viewDefault": "Xem mặc định",
+    "authorizationCode": "Mã xác thực",
+    "authorizationRequired": "Mã xác thực cần thiết để tạo Wiki"
   },
   "footer": {
     "copyright": "DeepWiki - Tài liệu hỗ trợ bởi AI cho repository"

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -79,7 +79,9 @@
     "changeModel": "修改模型",
     "defaultNote": "这些默认配置已经被应用。请在上方添加您的自定义排除项。",
     "hideDefault": "隐藏默认配置",
-    "viewDefault": "查看默认配置"
+    "viewDefault": "查看默认配置",
+    "authorizationCode": "授权码",
+    "authorizationRequired": "生成wiki页面需要填写授权码"
   },
   "footer": {
     "copyright": "DeepWiki - 为代码仓库提供AI驱动的文档"


### PR DESCRIPTION
This commit introduces an authorization mode for the wiki generation feature. When enabled via environment variables, you must provide a valid authorization code to generate a wiki.

Key changes:

- Backend:
    - Added `DEEPWIKI_AUTH_MODE` and `DEEPWIKI_AUTH_CODE` environment variables to control the feature.
    - Created an `/auth/status` endpoint to inform the frontend if auth is required.
    - Created an `/auth/validate` endpoint for validating the authorization code if auth is required.
    - Updated the Delete Wiki Cache request parameters to include an `auth_code`.
    - Implemented an authorization check in the Delete Wiki Cache handler to validate the `auth_code` if auth mode is active.
- Frontend:
    - The main page now fetches the auth status from the backend.
    - The configuration modal and the model selection modal conditionally display an input field for the authorization code if required.
    - The `auth_code` is sent to the backend for checking before the wiki generation request and during the wiki cache deletion.
- Documentation:
    - `README.md` and `README.zh.md` have been updated to explain the new environment variables and the authorization feature.

This allows administrators to restrict wiki generation capabilities to authorized users in the front end, but not prevent the redirect to backend generate interface. This is becauce that it hard to make diffrences the request is for asking or generating, and the more important thing for administrators is to protect the pages which have generated, but not prevent user to generate the own page.

So this can not prevent user to generate his own page completely but is aimed to protect the pages generated by  administrators.