### PR TITLE
doc: add env instructions for Ollama if not local

### DIFF
--- a/Ollama-instruction.md
+++ b/Ollama-instruction.md
@@ -47,6 +47,8 @@ Create a `.env` file in the project root:
 ```
 # No need for API keys when using Ollama locally
 PORT=8001
+# Optionally, provide OLLAMA_HOST if Ollama is not local
+OLLAMA_HOST=your_ollama_host # (default: http://localhost:11434)
 ```
 
 Start the backend:
@@ -78,11 +80,13 @@ npm run dev
    # For regular use
    docker run -p 3000:3000 -p 8001:8001 --name deepwiki \
      -v ~/.adalflow:/root/.adalflow \
+     -e OLLAMA_HOST=your_ollama_host \
      deepwiki:ollama-local
    
    # For local repository analysis
    docker run -p 3000:3000 -p 8001:8001 --name deepwiki \
      -v ~/.adalflow:/root/.adalflow \
+     -e OLLAMA_HOST=your_ollama_host \
      -v /path/to/your/repo:/app/local-repos/repo-name \
      deepwiki:ollama-local
    ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ echo "GOOGLE_API_KEY=your_google_api_key" > .env
 echo "OPENAI_API_KEY=your_openai_api_key" >> .env
 # Optional: Add OpenRouter API key if you want to use OpenRouter models
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" >> .env
+# Optional: Add Ollama host if not local
+echo "OLLAMA_HOST=https://your_ollama_host" >> .env
 
 # Run with Docker Compose
 docker-compose up
@@ -63,6 +65,8 @@ GOOGLE_API_KEY=your_google_api_key
 OPENAI_API_KEY=your_openai_api_key
 # Optional: Add this if you want to use OpenRouter models
 OPENROUTER_API_KEY=your_openrouter_api_key
+# Optional: Add Ollama host if not local
+OLLAMA_HOST=https://your_ollama_host
 ```
 
 #### Step 2: Start the Backend
@@ -190,6 +194,9 @@ OPENROUTER_API_KEY=your_openrouter_api_key # Required for OpenRouter models
 # OpenAI API Base URL Configuration
 OPENAI_BASE_URL=https://custom-api-endpoint.com/v1  # Optional, for custom OpenAI API endpoints
 
+# Ollama host
+OLLAMA_HOST=https://your_ollama_host # Optional, if Ollama is not local
+
 # Configuration Directory
 DEEPWIKI_CONFIG_DIR=/path/to/custom/config/dir  # Optional, for custom config file location
 ```
@@ -238,13 +245,14 @@ The OpenAI Client's base_url configuration is designed primarily for enterprise 
 
 ### Environment Variables
 
-| Variable | Description | Required | Note |
-|----------|-------------|----------|------|
-| `GOOGLE_API_KEY` | Google Gemini API key for AI generation | No | Required only if you want to use Google Gemini models
-| `OPENAI_API_KEY` | OpenAI API key for embeddings | Yes | Note: This is required even if you're not using OpenAI models, as it's used for embeddings. |
-| `OPENROUTER_API_KEY` | OpenRouter API key for alternative models | No | Required only if you want to use OpenRouter models |
-| `PORT` | Port for the API server (default: 8001) | No | If you host API and frontend on the same machine, make sure change port of `SERVER_BASE_URL` accordingly |
-| `SERVER_BASE_URL` | Base URL for the API server (default: http://localhost:8001) | No |
+| Variable             | Description                                                  | Required | Note                                                                                                     |
+|----------------------|--------------------------------------------------------------|----------|----------------------------------------------------------------------------------------------------------|
+| `GOOGLE_API_KEY`     | Google Gemini API key for AI generation                      | No | Required only if you want to use Google Gemini models                                                    
+| `OPENAI_API_KEY`     | OpenAI API key for embeddings                                | Yes | Note: This is required even if you're not using OpenAI models, as it's used for embeddings.              |
+| `OPENROUTER_API_KEY` | OpenRouter API key for alternative models                    | No | Required only if you want to use OpenRouter models                                                       |
+| `OLLAMA_HOST`        | Ollama Host (default: http://localhost:11434)                | No | Required only if you want to use external Ollama server                                                  |
+| `PORT`               | Port for the API server (default: 8001)                      | No | If you host API and frontend on the same machine, make sure change port of `SERVER_BASE_URL` accordingly |
+| `SERVER_BASE_URL`    | Base URL for the API server (default: http://localhost:8001) | No |
 
 If you're not using ollama mode, you need to configure an OpenAI API key for embeddings. Other API keys are only required when configuring and using models from the corresponding providers.
 
@@ -261,6 +269,7 @@ docker run -p 8001:8001 -p 3000:3000 \
   -e GOOGLE_API_KEY=your_google_api_key \
   -e OPENAI_API_KEY=your_openai_api_key \
   -e OPENROUTER_API_KEY=your_openrouter_api_key \
+  -e OLLAMA_HOST=your_ollama_host \
   -v ~/.adalflow:/root/.adalflow \
   ghcr.io/asyncfuncai/deepwiki-open:latest
 ```
@@ -290,6 +299,7 @@ You can also mount a .env file to the container:
 echo "GOOGLE_API_KEY=your_google_api_key" > .env
 echo "OPENAI_API_KEY=your_openai_api_key" >> .env
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" >> .env
+echo "OLLAMA_HOST=https://your_ollama_host" >> .env
 
 # Run the container with the .env file mounted
 docker run -p 8001:8001 -p 3000:3000 \
@@ -322,6 +332,7 @@ docker run -p 8001:8001 -p 3000:3000 \
   -e GOOGLE_API_KEY=your_google_api_key \
   -e OPENAI_API_KEY=your_openai_api_key \
   -e OPENROUTER_API_KEY=your_openrouter_api_key \
+  -e OLLAMA_HOST=your_ollama_host \
   deepwiki-open
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ echo "GOOGLE_API_KEY=your_google_api_key" > .env
 echo "OPENAI_API_KEY=your_openai_api_key" >> .env
 # Optional: Add OpenRouter API key if you want to use OpenRouter models
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" >> .env
-# Optional: Add Ollama host if not local
-echo "OLLAMA_HOST=https://your_ollama_host" >> .env
+# Optional: Add Ollama host if not local. defaults to http://localhost:11434
+echo "OLLAMA_HOST=your_ollama_host" >> .env
 
 # Run with Docker Compose
 docker-compose up
@@ -65,8 +65,8 @@ GOOGLE_API_KEY=your_google_api_key
 OPENAI_API_KEY=your_openai_api_key
 # Optional: Add this if you want to use OpenRouter models
 OPENROUTER_API_KEY=your_openrouter_api_key
-# Optional: Add Ollama host if not local
-OLLAMA_HOST=https://your_ollama_host
+# Optional: Add Ollama host if not local. default: http://localhost:11434
+OLLAMA_HOST=your_ollama_host
 ```
 
 #### Step 2: Start the Backend
@@ -195,7 +195,7 @@ OPENROUTER_API_KEY=your_openrouter_api_key # Required for OpenRouter models
 OPENAI_BASE_URL=https://custom-api-endpoint.com/v1  # Optional, for custom OpenAI API endpoints
 
 # Ollama host
-OLLAMA_HOST=https://your_ollama_host # Optional, if Ollama is not local
+OLLAMA_HOST=your_ollama_host # Optional, if Ollama is not local. default: http://localhost:11434
 
 # Configuration Directory
 DEEPWIKI_CONFIG_DIR=/path/to/custom/config/dir  # Optional, for custom config file location
@@ -299,7 +299,7 @@ You can also mount a .env file to the container:
 echo "GOOGLE_API_KEY=your_google_api_key" > .env
 echo "OPENAI_API_KEY=your_openai_api_key" >> .env
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" >> .env
-echo "OLLAMA_HOST=https://your_ollama_host" >> .env
+echo "OLLAMA_HOST=your_ollama_host" >> .env
 
 # Run the container with the .env file mounted
 docker run -p 8001:8001 -p 3000:3000 \

--- a/api/README.md
+++ b/api/README.md
@@ -34,6 +34,9 @@ OPENROUTER_API_KEY=your_openrouter_api_key  # Required only if using OpenRouter 
 # OpenAI API Configuration
 OPENAI_BASE_URL=https://custom-api-endpoint.com/v1  # Optional, for custom OpenAI API endpoints
 
+# Ollama host
+OLLAMA_HOST=https://your_ollama_host"  # Optional: Add Ollama host if not local. default: http://localhost:11434
+
 # Server Configuration
 PORT=8001  # Optional, defaults to 8001
 ```


### PR DESCRIPTION
Add instructions for `OLLAMA_HOST` env variable when using Ollama that is not local.