### PR TITLE
New option (data pipeline) for preparing fine-tuning data

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -91,9 +91,8 @@ def load_embedder_config():
             if class_name in CLIENT_CLASSES:
                 embedder_config[key]["model_client"] = CLIENT_CLASSES[class_name]
     
-    # Load the fine-tuning data prep default setting
-    # This is also set in the main config merging section for robustness
-    configs['fine_tuning_data_prep_default'] = embedder_config.get('enable_fine_tuning_data_prep_default', False)
+    # The fine-tuning data prep default setting is now exclusively handled
+    # in the main config merging section for robustness.
 
     return embedder_config
 

--- a/api/config.py
+++ b/api/config.py
@@ -90,6 +90,10 @@ def load_embedder_config():
             class_name = embedder_config[key]["client_class"]
             if class_name in CLIENT_CLASSES:
                 embedder_config[key]["model_client"] = CLIENT_CLASSES[class_name]
+    
+    # Load the fine-tuning data prep default setting
+    # This is also set in the main config merging section for robustness
+    configs['fine_tuning_data_prep_default'] = embedder_config.get('enable_fine_tuning_data_prep_default', False)
 
     return embedder_config
 
@@ -156,6 +160,8 @@ if embedder_config:
     for key in ["embedder", "embedder_ollama", "retriever", "text_splitter"]:
         if key in embedder_config:
             configs[key] = embedder_config[key]
+    # Ensure fine_tuning_data_prep_default is explicitly set from embedder_config
+    configs['fine_tuning_data_prep_default'] = embedder_config.get('enable_fine_tuning_data_prep_default', False)
 
 # Update repository configuration
 if repo_config:

--- a/api/config/embedder.json
+++ b/api/config/embedder.json
@@ -1,4 +1,6 @@
 {
+  "_comment_enable_fine_tuning_data_prep_default": "Sets the default behavior for data preparation. If true, data pipeline functions will default to preparing data for fine-tuning (e.g., not chunking, not embedding). If false (default), they will prepare data for RAG (chunking and embedding). This can be overridden by explicit parameters in function calls.",
+  "enable_fine_tuning_data_prep_default": false,
   "embedder": {
     "client_class": "OpenAIClient",
     "batch_size": 500,

--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -814,8 +814,12 @@ class DatabaseManager:
         logger.info(f"Total documents: {len(documents)}")
         # If chunk_for_fine_tuning is True, transformed_docs will be the same as documents
         # as transformation is skipped. Otherwise, get the transformed data.
-        transformed_docs = self.db.get_transformed_data(key="split_and_embed") if not chunk_for_fine_tuning else documents
-        logger.info(f"Total transformed documents: {len(transformed_docs)}")
+        if not chunk_for_fine_tuning:
+            transformed_docs = self.db.get_transformed_data(key="split_and_embed")
+            logger.info(f"Total transformed documents: {len(transformed_docs)}")
+        else:
+            transformed_docs = documents # These are the raw documents from read_all_documents
+            logger.info(f"Total raw documents prepared for fine-tuning: {len(transformed_docs)}")
         return transformed_docs
 
     def prepare_retriever(self, repo_url_or_path: str, type: str = "github", access_token: str = None):

--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -118,7 +118,7 @@ def download_repo(repo_url: str, local_path: str, type: str = "github", access_t
 download_github_repo = download_repo
 
 def read_all_documents(path: str, local_ollama: bool = False, excluded_dirs: List[str] = None, excluded_files: List[str] = None,
-                      included_dirs: List[str] = None, included_files: List[str] = None, chunk_for_fine_tuning: bool = False):
+                      included_dirs: List[str] = None, included_files: List[str] = None, chunk_for_fine_tuning: bool = configs.get('fine_tuning_data_prep_default', False)):
     """
     Recursively reads all documents in a directory and its subdirectories.
 
@@ -133,8 +133,8 @@ def read_all_documents(path: str, local_ollama: bool = False, excluded_dirs: Lis
             When provided, only files in these directories will be processed.
         included_files (List[str], optional): List of file patterns to include exclusively.
             When provided, only files matching these patterns will be processed.
-        chunk_for_fine_tuning (bool, optional): Whether to chunk documents for fine-tuning.
-            Default is False.
+        chunk_for_fine_tuning (bool, optional): Whether to prepare data for fine-tuning.
+            Defaults to the value of 'enable_fine_tuning_data_prep_default' in embedder.json (False if not set).
 
     Returns:
         list: A list of Document objects with metadata.
@@ -345,14 +345,15 @@ def read_all_documents(path: str, local_ollama: bool = False, excluded_dirs: Lis
     logger.info(f"Found {len(documents)} documents")
     return documents
 
-def prepare_data_pipeline(local_ollama: bool = False, chunk_for_fine_tuning: bool = False):
+def prepare_data_pipeline(local_ollama: bool = False, chunk_for_fine_tuning: bool = configs.get('fine_tuning_data_prep_default', False)):
     """
     Creates and returns the data transformation pipeline.
 
     Args:
         local_ollama (bool): Whether to use local Ollama for embedding (default: False)
-        chunk_for_fine_tuning (bool): Whether to prepare for fine-tuning (default: False).
-                                      If True, an empty pipeline is returned.
+        chunk_for_fine_tuning (bool, optional): Whether to prepare for fine-tuning.
+            Defaults to the value of 'enable_fine_tuning_data_prep_default' in embedder.json (False if not set).
+            If True, an empty pipeline is returned.
 
     Returns:
         adal.Sequential: The data transformation pipeline, or an empty one if chunk_for_fine_tuning is True.
@@ -385,7 +386,7 @@ def prepare_data_pipeline(local_ollama: bool = False, chunk_for_fine_tuning: boo
     return data_transformer
 
 def transform_documents_and_save_to_db(
-    documents: List[Document], db_path: str, local_ollama: bool = False, chunk_for_fine_tuning: bool = False
+    documents: List[Document], db_path: str, local_ollama: bool = False, chunk_for_fine_tuning: bool = configs.get('fine_tuning_data_prep_default', False)
 ) -> LocalDB:
     """
     Transforms a list of documents and saves them to a local database.
@@ -394,8 +395,9 @@ def transform_documents_and_save_to_db(
         documents (list): A list of `Document` objects.
         db_path (str): The path to the local database file.
         local_ollama (bool): Whether to use local Ollama for embedding (default: False)
-        chunk_for_fine_tuning (bool): Whether to save raw documents for fine-tuning (default: False).
-                                      If True, transformation is skipped.
+        chunk_for_fine_tuning (bool, optional): Whether to save raw documents for fine-tuning.
+            Defaults to the value of 'enable_fine_tuning_data_prep_default' in embedder.json (False if not set).
+            If True, transformation is skipped.
     """
     # Get the data transformer
     data_transformer = prepare_data_pipeline(local_ollama, chunk_for_fine_tuning)
@@ -661,7 +663,7 @@ class DatabaseManager:
 
     def prepare_database(self, repo_url_or_path: str, type: str = "github", access_token: str = None, local_ollama: bool = False,
                        excluded_dirs: List[str] = None, excluded_files: List[str] = None,
-                       included_dirs: List[str] = None, included_files: List[str] = None, chunk_for_fine_tuning: bool = False) -> List[Document]:
+                       included_dirs: List[str] = None, included_files: List[str] = None, chunk_for_fine_tuning: bool = configs.get('fine_tuning_data_prep_default', False)) -> List[Document]:
         """
         Create a new database from the repository.
 
@@ -673,7 +675,8 @@ class DatabaseManager:
             excluded_files (List[str], optional): List of file patterns to exclude from processing
             included_dirs (List[str], optional): List of directories to include exclusively
             included_files (List[str], optional): List of file patterns to include exclusively
-            chunk_for_fine_tuning (bool, optional): Whether to prepare data for fine-tuning. Default is False.
+            chunk_for_fine_tuning (bool, optional): Whether to prepare data for fine-tuning.
+                Defaults to the value of 'enable_fine_tuning_data_prep_default' in embedder.json (False if not set).
 
         Returns:
             List[Document]: List of Document objects
@@ -753,7 +756,7 @@ class DatabaseManager:
             raise
 
     def prepare_db_index(self, local_ollama: bool = False, excluded_dirs: List[str] = None, excluded_files: List[str] = None,
-                        included_dirs: List[str] = None, included_files: List[str] = None, chunk_for_fine_tuning: bool = False) -> List[Document]:
+                        included_dirs: List[str] = None, included_files: List[str] = None, chunk_for_fine_tuning: bool = configs.get('fine_tuning_data_prep_default', False)) -> List[Document]:
         """
         Prepare the indexed database for the repository.
 
@@ -763,7 +766,8 @@ class DatabaseManager:
             excluded_files (List[str], optional): List of file patterns to exclude from processing
             included_dirs (List[str], optional): List of directories to include exclusively
             included_files (List[str], optional): List of file patterns to include exclusively
-            chunk_for_fine_tuning (bool, optional): Whether to prepare data for fine-tuning. Default is False.
+            chunk_for_fine_tuning (bool, optional): Whether to prepare data for fine-tuning.
+                Defaults to the value of 'enable_fine_tuning_data_prep_default' in embedder.json (False if not set).
 
         Returns:
             List[Document]: List of Document objects

--- a/api/test_data_pipeline.py
+++ b/api/test_data_pipeline.py
@@ -1,270 +1,330 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY # Added ANY
 import os
-import shutil # For cleaning up test directory
+import shutil
+from adalflow import Sequential # Corrected import
+from adalflow.core.component import Component
 from adalflow.core.types import Document
-from adalflow.core.db import LocalDB
-from adalflow.core.pipelines import Sequential # For checking pipeline type
+from adalflow.core.db import LocalDB # For type hinting if needed, though direct use is mocked
 
 # Assume api.data_pipeline and other necessary imports are available
-# You might need to adjust imports based on the actual project structure
-from api.data_pipeline import DatabaseManager, read_all_documents, prepare_data_pipeline, transform_documents_and_save_to_db 
-from api.config import configs # To get text_splitter config
+from api.data_pipeline import DatabaseManager, read_all_documents, prepare_data_pipeline, transform_documents_and_save_to_db
+from api.config import configs
 
 # Sample file content
 SAMPLE_FILE_CONTENT_NORMAL = "This is a sample document with several words. It should be chunked for RAG."
-SAMPLE_FILE_CONTENT_LARGE = "This is a very large document. " * 500 # Approx 2500 words, should exceed normal chunk size
-TEST_REPO_PARENT_DIR = "test_temp_data" # Parent for test repo to avoid clutter
+SAMPLE_FILE_CONTENT_LARGE = "This is a very large document. " * 500 # Approx 2500 words
+TEST_REPO_PARENT_DIR = "test_temp_data_pipeline" # Unique name
 TEST_REPO_PATH = os.path.join(TEST_REPO_PARENT_DIR, "test_repo")
 TEST_FILE_NORMAL = os.path.join(TEST_REPO_PATH, "normal_doc.txt")
 TEST_FILE_LARGE = os.path.join(TEST_REPO_PATH, "large_doc.txt")
 TEST_DB_PATH = os.path.join(TEST_REPO_PARENT_DIR, "test_db.pkl")
 
+# --- Stub Adalflow Components ---
+class StubComponent(Component):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.process_logic_mock = MagicMock(return_value=[Document(text="stub_transformed_output", meta_data={'embedding': [0.1, 0.2]})])
+        self.init_args = args
+        self.init_kwargs = kwargs
+        self.call_invoked_count = 0 # Debug counter
 
+    def call(self, documents: list[Document], **kwargs) -> list[Document]:
+        print(f"DEBUG: {self.__class__.__name__}.call invoked with {len(documents)} docs, kwargs: {kwargs}") # DEBUG PRINT
+        self.call_invoked_count += 1
+        return self.process_logic_mock(documents, **kwargs) # Ensure kwargs are passed
+
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.init_args}, {self.init_kwargs})"
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.init_args}, {self.init_kwargs})"
+
+class StubTextSplitter(StubComponent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Simulate splitting by returning multiple documents based on a simple word count for testing
+        def split_effect(documents, **inner_kwargs):
+            output_docs = []
+            for doc in documents:
+                words = doc.text.split()
+                # Example: split if more than 5 words, just for testing
+                # Also check file_path in meta_data to be more specific for the large doc
+                if len(words) > 5 and doc.meta_data and "large_doc" in doc.meta_data.get("file_path",""): 
+                    output_docs.append(Document(text=" ".join(words[:5]), meta_data=doc.meta_data))
+                    output_docs.append(Document(text=" ".join(words[5:]), meta_data=doc.meta_data))
+                else:
+                    output_docs.append(Document(text=doc.text, meta_data=doc.meta_data)) # No split if short
+            return output_docs
+        self.process_logic_mock.side_effect = split_effect
+
+
+class StubToEmbeddings(StubComponent):
+    def __init__(self, embedder, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.embedder = embedder
+        def add_embedding_side_effect(documents, **inner_kwargs):
+            processed_docs = []
+            for doc_idx, doc in enumerate(documents):
+                new_meta = doc.meta_data.copy() if doc.meta_data else {}
+                new_meta['embedding'] = [0.1 + doc_idx, 0.2, 0.3] # Dummy embedding
+                processed_docs.append(Document(text=doc.text, meta_data=new_meta))
+            return processed_docs
+        self.process_logic_mock.side_effect = add_embedding_side_effect
+
+class StubOllamaDocumentProcessor(StubComponent):
+    def __init__(self, embedder, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.embedder = embedder
+        def add_ollama_embedding_side_effect(documents, **inner_kwargs):
+            processed_docs = []
+            for doc_idx, doc in enumerate(documents):
+                new_meta = doc.meta_data.copy() if doc.meta_data else {}
+                new_meta['embedding'] = [0.4 + doc_idx, 0.5, 0.6] # Dummy Ollama embedding
+                processed_docs.append(Document(text=doc.text, meta_data=new_meta))
+            return processed_docs
+        self.process_logic_mock.side_effect = add_ollama_embedding_side_effect
+
+# --- Test Class ---
 class TestDataPipelineFineTuning(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # Create dummy repo and files for testing
         os.makedirs(TEST_REPO_PATH, exist_ok=True)
         with open(TEST_FILE_NORMAL, "w") as f:
-            f.write(SAMPLE_FILE_CONTENT_NORMAL)
+            # Make normal_doc.txt have more than 5 words to test splitter's non-large-file path
+            cls.normal_file_content = SAMPLE_FILE_CONTENT_NORMAL + " some extra words for testing."
+            f.write(cls.normal_file_content)
         with open(TEST_FILE_LARGE, "w") as f:
             f.write(SAMPLE_FILE_CONTENT_LARGE)
 
-        # Store original adalflow root path and set a temporary one for tests
         cls.original_adalflow_root = os.environ.get("ADALFLOW_ROOT_PATH")
         os.environ["ADALFLOW_ROOT_PATH"] = TEST_REPO_PARENT_DIR
         
-        # Mock configurations if necessary
-        cls.original_text_splitter_config = configs.get("text_splitter")
-        # Ensure a small chunk size for testing RAG path splitting
+        cls.original_openai_api_key = os.environ.get("OPENAI_API_KEY")
+        os.environ["OPENAI_API_KEY"] = "test_key_dummy"
+
+        cls.original_text_splitter_config = configs.get("text_splitter", {}).copy()
+        # Ensure meta_data_to_attach is part of the default test config for text_splitter
+        configs["text_splitter"] = {"split_by": "word", "chunk_size": 10, "chunk_overlap": 2, "meta_data_to_attach": {"source_test_splitter": "test_val"} }
+        
         cls.original_fine_tuning_default = configs.get('fine_tuning_data_prep_default')
-        configs["text_splitter"] = {"split_by": "word", "chunk_size": 10, "chunk_overlap": 2} 
+
 
     @classmethod
     def tearDownClass(cls):
-        # Restore original config and remove dummy files/dirs
-        if cls.original_text_splitter_config:
-            configs["text_splitter"] = cls.original_text_splitter_config
+        if cls.original_adalflow_root is None:
+            if "ADALFLOW_ROOT_PATH" in os.environ: del os.environ["ADALFLOW_ROOT_PATH"]
         else:
-            if "text_splitter" in configs:
-                del configs["text_splitter"]
+            os.environ["ADALFLOW_ROOT_PATH"] = cls.original_adalflow_root
+
+        if cls.original_openai_api_key is None:
+            if "OPENAI_API_KEY" in os.environ and os.environ.get("OPENAI_API_KEY") == "test_key_dummy":
+                del os.environ["OPENAI_API_KEY"]
+        else:
+            os.environ["OPENAI_API_KEY"] = cls.original_openai_api_key
+
+        configs["text_splitter"] = cls.original_text_splitter_config
         
         if cls.original_fine_tuning_default is None:
             if 'fine_tuning_data_prep_default' in configs:
                 del configs['fine_tuning_data_prep_default']
         else:
             configs['fine_tuning_data_prep_default'] = cls.original_fine_tuning_default
-        
-        if cls.original_adalflow_root is None:
-            del os.environ["ADALFLOW_ROOT_PATH"]
-        else:
-            os.environ["ADALFLOW_ROOT_PATH"] = cls.original_adalflow_root
 
         if os.path.exists(TEST_REPO_PARENT_DIR):
             shutil.rmtree(TEST_REPO_PARENT_DIR)
 
     def setUp(self):
-        # Patch LocalDB methods to prevent actual file I/O for the DB file itself during most tests
-        # We want to test the DB creation logic but not necessarily disk writes unless specified
-        patcher_load_state = patch('adalflow.core.db.LocalDB.load_state', MagicMock(side_effect=FileNotFoundError("Mock: DB not found"))) # Simulate no existing DB
-        patcher_save_state = patch('adalflow.core.db.LocalDB.save_state', MagicMock(return_value=None))
+        patcher_load_state = patch('api.data_pipeline.LocalDB.load_state', MagicMock(side_effect=FileNotFoundError("Mock: DB not found")))
+        patcher_save_state = patch('api.data_pipeline.LocalDB.save_state', MagicMock(return_value=None))
+        patcher_transform = patch('api.data_pipeline.LocalDB.transform', MagicMock(return_value=None))
         
         self.mock_load_state = patcher_load_state.start()
         self.mock_save_state = patcher_save_state.start()
+        self.mock_transform = patcher_transform.start()
         
         self.addCleanup(patcher_load_state.stop)
         self.addCleanup(patcher_save_state.stop)
+        self.addCleanup(patcher_transform.stop)
 
-    @patch('api.data_pipeline.OllamaDocumentProcessor') # Mock Ollama processor
-    @patch('api.data_pipeline.ToEmbeddings') # Mock OpenAI embedder
-    @patch('api.data_pipeline.TextSplitter')
+    # --- Test Cases ---
+
+    @patch('api.data_pipeline.OllamaDocumentProcessor', new_callable=MagicMock)
+    @patch('api.data_pipeline.ToEmbeddings', new_callable=MagicMock)
+    @patch('api.data_pipeline.TextSplitter', new_callable=MagicMock)
     def test_processing_for_rag_default(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
-        # Test default behavior (chunk_for_fine_tuning=False)
-        # Explicitly set for this test to ensure RAG path regardless of JSON default
-        configs['fine_tuning_data_prep_default'] = False
+        configs['fine_tuning_data_prep_default'] = True 
 
-        mock_splitter_instance = MockTextSplitter.return_value
-        mock_embedder_instance = MockToEmbeddings.return_value
+        MockTextSplitter.return_value = StubTextSplitter(**configs["text_splitter"])
+        MockToEmbeddings.return_value = StubToEmbeddings(embedder=MagicMock())
         
-        # Ensure TextSplitter and ToEmbeddings are used
-        MockTextSplitter.return_value = MagicMock(spec=configs["text_splitter"])
-        MockToEmbeddings.return_value = MagicMock()
-        MockOllamaProcessor.return_value = MagicMock()
-
-
         db_manager = DatabaseManager()
-        # Override repo_paths to use our test paths
-        db_manager.repo_paths = {
-            "save_repo_dir": TEST_REPO_PATH,
-            "save_db_file": TEST_DB_PATH
-        }
-        # Call prepare_db_index directly to bypass git clone for local files
-        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=False)
+        db_manager.repo_paths = {"save_repo_dir": TEST_REPO_PATH, "save_db_file": TEST_DB_PATH}
+        processed_docs = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=False)
 
-        MockTextSplitter.assert_called_with(**configs["text_splitter"])
-        MockToEmbeddings.assert_called() # or MockOllamaProcessor if local_ollama=True
+        MockTextSplitter.assert_called_once_with(**configs["text_splitter"])
+        MockTextSplitter.return_value.process_logic_mock.assert_called()
+        MockToEmbeddings.assert_called_once_with(embedder=ANY)
+        MockToEmbeddings.return_value.process_logic_mock.assert_called()
+        MockOllamaProcessor.assert_not_called()
+        self.mock_transform.assert_called_once_with(key="split_and_embed")
         
-        # Verify that the transformation key was registered
-        # This requires inspecting the db instance after processing
-        self.assertIn("split_and_embed", db_manager.db.transformers)
-        
-        # Check that documents are split (example assertion)
-        # We expect more documents than original files due to splitting
-        original_file_count = 2
-        self.assertGreater(len(processed_docs_objects), original_file_count)
-
-        # Check if text from large doc is smaller than original, indicating splitting
-        large_doc_texts = [doc.text for doc in processed_docs_objects if doc.meta_data.get('file_path') == "large_doc.txt"]
-        self.assertTrue(any(len(text.split()) < len(SAMPLE_FILE_CONTENT_LARGE.split()) for text in large_doc_texts))
+        # StubTextSplitter splits large_doc.txt (identified by "large_doc" in path) into 2.
+        # normal_doc.txt (content updated in setUpClass) is NOT split by the stub's current logic as it doesn't contain "large_doc" in path.
+        # So, 1 (normal_doc) + 2 (large_doc parts) = 3 documents.
+        self.assertEqual(len(processed_docs), 3) 
+        for doc in processed_docs:
+            self.assertIn('embedding', doc.meta_data) # From StubToEmbeddings
+            if "large_doc" not in doc.meta_data.get("file_path",""): # normal_doc
+                 self.assertEqual(doc.text, self.normal_file_content) # Not split
+            else: # large_doc parts
+                 self.assertTrue(doc.text.startswith("This is a very large document.") or doc.text.startswith("document. This is a very large document."))
 
 
-    @patch('api.data_pipeline.OllamaDocumentProcessor')
-    @patch('api.data_pipeline.ToEmbeddings')
-    @patch('api.data_pipeline.TextSplitter')
+        self.mock_transform.reset_mock()
+
+    @patch('api.data_pipeline.OllamaDocumentProcessor', new_callable=MagicMock)
+    @patch('api.data_pipeline.ToEmbeddings', new_callable=MagicMock)
+    @patch('api.data_pipeline.TextSplitter', new_callable=MagicMock)
     def test_processing_for_fine_tuning_true(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
-        # Test behavior with chunk_for_fine_tuning=True
-        # Explicitly set for this test to ensure fine-tuning path
-        configs['fine_tuning_data_prep_default'] = True
+        configs['fine_tuning_data_prep_default'] = False 
 
         db_manager = DatabaseManager()
-        db_manager.repo_paths = {
-            "save_repo_dir": TEST_REPO_PATH,
-            "save_db_file": TEST_DB_PATH
-        }
-        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=True)
+        db_manager.repo_paths = {"save_repo_dir": TEST_REPO_PATH, "save_db_file": TEST_DB_PATH}
+        processed_docs = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=True)
 
         MockTextSplitter.assert_not_called()
         MockToEmbeddings.assert_not_called()
         MockOllamaProcessor.assert_not_called()
+        self.mock_transform.assert_not_called()
         
-        # Verify that the transformation key was NOT registered
-        self.assertNotIn("split_and_embed", db_manager.db.transformers)
+        self.assertEqual(len(processed_docs), 2) 
+        texts = {doc.meta_data['file_path']: doc.text for doc in processed_docs}
+        self.assertEqual(texts["normal_doc.txt"], self.normal_file_content)
+        self.assertEqual(texts["large_doc.txt"], SAMPLE_FILE_CONTENT_LARGE)
+        self.mock_transform.reset_mock()
 
-        # Assert that documents are not split and contain full content
-        self.assertEqual(len(processed_docs_objects), 2) # Should be same number as input files
-        
-        found_large_doc = False
-        found_normal_doc = False
-        for doc in processed_docs_objects:
-            if doc.meta_data.get('file_path') == "large_doc.txt":
-                self.assertEqual(doc.text, SAMPLE_FILE_CONTENT_LARGE)
-                found_large_doc = True
-            if doc.meta_data.get('file_path') == "normal_doc.txt":
-                self.assertEqual(doc.text, SAMPLE_FILE_CONTENT_NORMAL)
-                found_normal_doc = True
 
-        self.assertTrue(found_large_doc)
-        self.assertTrue(found_normal_doc)
-
-    def test_prepare_data_pipeline_rag(self):
-        # Test that prepare_data_pipeline returns a Sequential pipeline for RAG
-        pipeline = prepare_data_pipeline(local_ollama=False, chunk_for_fine_tuning=False)
-        self.assertIsInstance(pipeline, Sequential)
-        self.assertTrue(len(pipeline.steps) > 0) # Should have steps (splitter, embedder)
-
-    def test_prepare_data_pipeline_fine_tuning(self):
-        # Test that prepare_data_pipeline returns an empty Sequential pipeline for fine-tuning
-        pipeline = prepare_data_pipeline(local_ollama=False, chunk_for_fine_tuning=True)
-        self.assertIsInstance(pipeline, Sequential)
-        self.assertEqual(len(pipeline.steps), 0) # Should be empty
-
-    @patch('api.data_pipeline.OllamaDocumentProcessor')
-    @patch('api.data_pipeline.ToEmbeddings')
-    @patch('api.data_pipeline.TextSplitter')
+    @patch('api.data_pipeline.OllamaDocumentProcessor', new_callable=MagicMock)
+    @patch('api.data_pipeline.ToEmbeddings', new_callable=MagicMock)
+    @patch('api.data_pipeline.TextSplitter', new_callable=MagicMock)
     def test_behavior_with_json_default_true(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
         configs['fine_tuning_data_prep_default'] = True
+
         db_manager = DatabaseManager()
-        db_manager.repo_paths = {
-            "save_repo_dir": TEST_REPO_PATH,
-            "save_db_file": TEST_DB_PATH
-        }
-        # Call prepare_db_index WITHOUT chunk_for_fine_tuning, relying on default from configs
-        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False)
+        db_manager.repo_paths = {"save_repo_dir": TEST_REPO_PATH, "save_db_file": TEST_DB_PATH}
+        processed_docs = db_manager.prepare_db_index(local_ollama=False) 
 
         MockTextSplitter.assert_not_called()
         MockToEmbeddings.assert_not_called()
         MockOllamaProcessor.assert_not_called()
-        self.assertNotIn("split_and_embed", db_manager.db.transformers)
-        self.assertEqual(len(processed_docs_objects), 2)
-        found_large_doc = any(doc.meta_data.get('file_path') == "large_doc.txt" and doc.text == SAMPLE_FILE_CONTENT_LARGE for doc in processed_docs_objects)
-        found_normal_doc = any(doc.meta_data.get('file_path') == "normal_doc.txt" and doc.text == SAMPLE_FILE_CONTENT_NORMAL for doc in processed_docs_objects)
-        self.assertTrue(found_large_doc)
-        self.assertTrue(found_normal_doc)
+        self.mock_transform.assert_not_called()
+        self.assertEqual(len(processed_docs), 2)
+        self.mock_transform.reset_mock()
 
-    @patch('api.data_pipeline.OllamaDocumentProcessor')
-    @patch('api.data_pipeline.ToEmbeddings')
-    @patch('api.data_pipeline.TextSplitter')
+    @patch('api.data_pipeline.OllamaDocumentProcessor', new_callable=MagicMock)
+    @patch('api.data_pipeline.ToEmbeddings', new_callable=MagicMock)
+    @patch('api.data_pipeline.TextSplitter', new_callable=MagicMock)
     def test_behavior_with_json_default_false(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
         configs['fine_tuning_data_prep_default'] = False
-        MockTextSplitter.return_value = MagicMock(spec=configs["text_splitter"])
-        MockToEmbeddings.return_value = MagicMock()
-        MockOllamaProcessor.return_value = MagicMock()
+
+        MockTextSplitter.return_value = StubTextSplitter(**configs["text_splitter"])
+        MockToEmbeddings.return_value = StubToEmbeddings(embedder=MagicMock())
 
         db_manager = DatabaseManager()
-        db_manager.repo_paths = {
-            "save_repo_dir": TEST_REPO_PATH,
-            "save_db_file": TEST_DB_PATH
-        }
-        # Call prepare_db_index WITHOUT chunk_for_fine_tuning, relying on default from configs
-        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False)
+        db_manager.repo_paths = {"save_repo_dir": TEST_REPO_PATH, "save_db_file": TEST_DB_PATH}
+        processed_docs = db_manager.prepare_db_index(local_ollama=False)
 
-        MockTextSplitter.assert_called_with(**configs["text_splitter"])
-        MockToEmbeddings.assert_called()
-        self.assertIn("split_and_embed", db_manager.db.transformers)
-        self.assertGreater(len(processed_docs_objects), 2)
-        large_doc_texts = [doc.text for doc in processed_docs_objects if doc.meta_data.get('file_path') == "large_doc.txt"]
-        self.assertTrue(any(len(text.split()) < len(SAMPLE_FILE_CONTENT_LARGE.split()) for text in large_doc_texts))
+        MockTextSplitter.assert_called_once_with(**configs["text_splitter"])
+        
+        # Assert that the call method of the stubs was invoked
+        self.assertGreater(MockTextSplitter.return_value.call_invoked_count, 0, "StubTextSplitter.call was not invoked")
+        self.assertGreater(MockToEmbeddings.return_value.call_invoked_count, 0, "StubToEmbeddings.call was not invoked")
 
-    @patch('api.data_pipeline.OllamaDocumentProcessor')
-    @patch('api.data_pipeline.ToEmbeddings')
-    @patch('api.data_pipeline.TextSplitter')
+        MockTextSplitter.return_value.process_logic_mock.assert_called()
+        MockToEmbeddings.assert_called_once_with(embedder=ANY) # Constructor assertion
+        MockToEmbeddings.return_value.process_logic_mock.assert_called()
+        self.mock_transform.assert_called_once_with(key="split_and_embed")
+        self.assertEqual(len(processed_docs), 3)
+        self.mock_transform.reset_mock()
+
+    @patch('api.data_pipeline.OllamaDocumentProcessor', new_callable=MagicMock)
+    @patch('api.data_pipeline.ToEmbeddings', new_callable=MagicMock)
+    @patch('api.data_pipeline.TextSplitter', new_callable=MagicMock)
     def test_override_json_default_true_with_false_param(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
-        configs['fine_tuning_data_prep_default'] = True # JSON default is TRUE
-        MockTextSplitter.return_value = MagicMock(spec=configs["text_splitter"])
-        MockToEmbeddings.return_value = MagicMock()
-        MockOllamaProcessor.return_value = MagicMock()
+        configs['fine_tuning_data_prep_default'] = True 
+
+        MockTextSplitter.return_value = StubTextSplitter(**configs["text_splitter"])
+        MockToEmbeddings.return_value = StubToEmbeddings(embedder=MagicMock())
 
         db_manager = DatabaseManager()
-        db_manager.repo_paths = {
-            "save_repo_dir": TEST_REPO_PATH,
-            "save_db_file": TEST_DB_PATH
-        }
-        # Override with chunk_for_fine_tuning=False parameter
-        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=False)
+        db_manager.repo_paths = {"save_repo_dir": TEST_REPO_PATH, "save_db_file": TEST_DB_PATH}
+        processed_docs = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=False) 
 
-        MockTextSplitter.assert_called_with(**configs["text_splitter"])
-        MockToEmbeddings.assert_called()
-        self.assertIn("split_and_embed", db_manager.db.transformers)
-        self.assertGreater(len(processed_docs_objects), 2)
-        large_doc_texts = [doc.text for doc in processed_docs_objects if doc.meta_data.get('file_path') == "large_doc.txt"]
-        self.assertTrue(any(len(text.split()) < len(SAMPLE_FILE_CONTENT_LARGE.split()) for text in large_doc_texts))
+        MockTextSplitter.assert_called_once_with(**configs["text_splitter"])
+        MockToEmbeddings.assert_called_once_with(embedder=ANY)
+        self.mock_transform.assert_called_once_with(key="split_and_embed")
+        self.assertEqual(len(processed_docs), 3)
+        self.mock_transform.reset_mock()
 
-    @patch('api.data_pipeline.OllamaDocumentProcessor')
-    @patch('api.data_pipeline.ToEmbeddings')
-    @patch('api.data_pipeline.TextSplitter')
+    @patch('api.data_pipeline.OllamaDocumentProcessor', new_callable=MagicMock)
+    @patch('api.data_pipeline.ToEmbeddings', new_callable=MagicMock)
+    @patch('api.data_pipeline.TextSplitter', new_callable=MagicMock)
     def test_override_json_default_false_with_true_param(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
-        configs['fine_tuning_data_prep_default'] = False # JSON default is FALSE
+        configs['fine_tuning_data_prep_default'] = False 
 
         db_manager = DatabaseManager()
-        db_manager.repo_paths = {
-            "save_repo_dir": TEST_REPO_PATH,
-            "save_db_file": TEST_DB_PATH
-        }
-        # Override with chunk_for_fine_tuning=True parameter
-        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=True)
+        db_manager.repo_paths = {"save_repo_dir": TEST_REPO_PATH, "save_db_file": TEST_DB_PATH}
+        processed_docs = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=True)
 
         MockTextSplitter.assert_not_called()
         MockToEmbeddings.assert_not_called()
-        MockOllamaProcessor.assert_not_called()
-        self.assertNotIn("split_and_embed", db_manager.db.transformers)
-        self.assertEqual(len(processed_docs_objects), 2)
-        found_large_doc = any(doc.meta_data.get('file_path') == "large_doc.txt" and doc.text == SAMPLE_FILE_CONTENT_LARGE for doc in processed_docs_objects)
-        found_normal_doc = any(doc.meta_data.get('file_path') == "normal_doc.txt" and doc.text == SAMPLE_FILE_CONTENT_NORMAL for doc in processed_docs_objects)
-        self.assertTrue(found_large_doc)
-        self.assertTrue(found_normal_doc)
+        self.mock_transform.assert_not_called()
+        self.assertEqual(len(processed_docs), 2)
+        self.mock_transform.reset_mock()
+
+    def test_prepare_data_pipeline_rag(self):
+        with patch('api.data_pipeline.TextSplitter', new_callable=MagicMock) as MockTextSplitter, \
+             patch('api.data_pipeline.ToEmbeddings', new_callable=MagicMock) as MockToEmbeddings:
+            
+            # Configure the main mocks to return STUB instances
+            MockTextSplitter.return_value = StubTextSplitter(**configs["text_splitter"])
+            MockToEmbeddings.return_value = StubToEmbeddings(embedder=MagicMock())
+            
+            pipeline = prepare_data_pipeline(local_ollama=False, chunk_for_fine_tuning=False)
+            self.assertIsInstance(pipeline, Sequential)
+            
+            # Check that the actual component constructors were called by prepare_data_pipeline
+            MockTextSplitter.assert_called_once_with(**configs["text_splitter"])
+            MockToEmbeddings.assert_called_once_with(embedder=ANY)
+
+            # Behavioral check of the returned pipeline
+            dummy_doc = Document(text="test input for rag pipeline that is long enough to be split by stub")
+            output_docs = pipeline([dummy_doc]) 
+
+            # Check that stubs' process_logic_mock was called
+            MockTextSplitter.return_value.process_logic_mock.assert_called()
+            MockToEmbeddings.return_value.process_logic_mock.assert_called()
+            
+            # Based on StubTextSplitter splitting if >5 words (and not "large_doc" in path)
+            # and StubToEmbeddings adding embeddings
+            # "test input for rag pipeline that is long enough to be split by stub" -> 13 words, will be split by stub
+            # So it will be split into 2 by the stub, then both get embeddings.
+            self.assertEqual(len(output_docs), 2) 
+            for doc in output_docs:
+                 self.assertIn('embedding', doc.meta_data)
+
+
+    def test_prepare_data_pipeline_fine_tuning(self):
+        pipeline = prepare_data_pipeline(local_ollama=False, chunk_for_fine_tuning=True)
+        self.assertIsInstance(pipeline, Sequential)
+        
+        dummy_doc = Document(text="test input")
+        output_docs = pipeline([dummy_doc]) 
+        self.assertEqual(len(output_docs), 1)
+        self.assertIs(output_docs[0], dummy_doc) 
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/api/test_data_pipeline.py
+++ b/api/test_data_pipeline.py
@@ -28,7 +28,7 @@ class StubComponent(Component):
         self.init_args = args
         self.init_kwargs = kwargs
 
-    def call(self, documents: list[Document], **kwargs) -> list[Document]:
+    def __call__(self, documents: list[Document], **kwargs) -> list[Document]:
         # DEBUG PRINT and counter removed
         return self.process_logic_mock(documents, **kwargs) # Ensure kwargs are passed
 

--- a/api/test_data_pipeline.py
+++ b/api/test_data_pipeline.py
@@ -1,0 +1,162 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import shutil # For cleaning up test directory
+from adalflow.core.types import Document
+from adalflow.core.db import LocalDB
+from adalflow.core.pipelines import Sequential # For checking pipeline type
+
+# Assume api.data_pipeline and other necessary imports are available
+# You might need to adjust imports based on the actual project structure
+from api.data_pipeline import DatabaseManager, read_all_documents, prepare_data_pipeline, transform_documents_and_save_to_db 
+from api.config import configs # To get text_splitter config
+
+# Sample file content
+SAMPLE_FILE_CONTENT_NORMAL = "This is a sample document with several words. It should be chunked for RAG."
+SAMPLE_FILE_CONTENT_LARGE = "This is a very large document. " * 500 # Approx 2500 words, should exceed normal chunk size
+TEST_REPO_PARENT_DIR = "test_temp_data" # Parent for test repo to avoid clutter
+TEST_REPO_PATH = os.path.join(TEST_REPO_PARENT_DIR, "test_repo")
+TEST_FILE_NORMAL = os.path.join(TEST_REPO_PATH, "normal_doc.txt")
+TEST_FILE_LARGE = os.path.join(TEST_REPO_PATH, "large_doc.txt")
+TEST_DB_PATH = os.path.join(TEST_REPO_PARENT_DIR, "test_db.pkl")
+
+
+class TestDataPipelineFineTuning(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Create dummy repo and files for testing
+        os.makedirs(TEST_REPO_PATH, exist_ok=True)
+        with open(TEST_FILE_NORMAL, "w") as f:
+            f.write(SAMPLE_FILE_CONTENT_NORMAL)
+        with open(TEST_FILE_LARGE, "w") as f:
+            f.write(SAMPLE_FILE_CONTENT_LARGE)
+
+        # Store original adalflow root path and set a temporary one for tests
+        cls.original_adalflow_root = os.environ.get("ADALFLOW_ROOT_PATH")
+        os.environ["ADALFLOW_ROOT_PATH"] = TEST_REPO_PARENT_DIR
+        
+        # Mock configurations if necessary
+        cls.original_text_splitter_config = configs.get("text_splitter")
+        # Ensure a small chunk size for testing RAG path splitting
+        configs["text_splitter"] = {"split_by": "word", "chunk_size": 10, "chunk_overlap": 2} 
+
+    @classmethod
+    def tearDownClass(cls):
+        # Restore original config and remove dummy files/dirs
+        if cls.original_text_splitter_config:
+            configs["text_splitter"] = cls.original_text_splitter_config
+        else:
+            if "text_splitter" in configs:
+                del configs["text_splitter"]
+        
+        if cls.original_adalflow_root is None:
+            del os.environ["ADALFLOW_ROOT_PATH"]
+        else:
+            os.environ["ADALFLOW_ROOT_PATH"] = cls.original_adalflow_root
+
+        if os.path.exists(TEST_REPO_PARENT_DIR):
+            shutil.rmtree(TEST_REPO_PARENT_DIR)
+
+    def setUp(self):
+        # Patch LocalDB methods to prevent actual file I/O for the DB file itself during most tests
+        # We want to test the DB creation logic but not necessarily disk writes unless specified
+        patcher_load_state = patch('adalflow.core.db.LocalDB.load_state', MagicMock(side_effect=FileNotFoundError("Mock: DB not found"))) # Simulate no existing DB
+        patcher_save_state = patch('adalflow.core.db.LocalDB.save_state', MagicMock(return_value=None))
+        
+        self.mock_load_state = patcher_load_state.start()
+        self.mock_save_state = patcher_save_state.start()
+        
+        self.addCleanup(patcher_load_state.stop)
+        self.addCleanup(patcher_save_state.stop)
+
+    @patch('api.data_pipeline.OllamaDocumentProcessor') # Mock Ollama processor
+    @patch('api.data_pipeline.ToEmbeddings') # Mock OpenAI embedder
+    @patch('api.data_pipeline.TextSplitter')
+    def test_processing_for_rag_default(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
+        # Test default behavior (chunk_for_fine_tuning=False)
+        mock_splitter_instance = MockTextSplitter.return_value
+        mock_embedder_instance = MockToEmbeddings.return_value
+        
+        # Ensure TextSplitter and ToEmbeddings are used
+        MockTextSplitter.return_value = MagicMock(spec=configs["text_splitter"])
+        MockToEmbeddings.return_value = MagicMock()
+        MockOllamaProcessor.return_value = MagicMock()
+
+
+        db_manager = DatabaseManager()
+        # Override repo_paths to use our test paths
+        db_manager.repo_paths = {
+            "save_repo_dir": TEST_REPO_PATH,
+            "save_db_file": TEST_DB_PATH
+        }
+        # Call prepare_db_index directly to bypass git clone for local files
+        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=False)
+
+        MockTextSplitter.assert_called_with(**configs["text_splitter"])
+        MockToEmbeddings.assert_called() # or MockOllamaProcessor if local_ollama=True
+        
+        # Verify that the transformation key was registered
+        # This requires inspecting the db instance after processing
+        self.assertIn("split_and_embed", db_manager.db.transformers)
+        
+        # Check that documents are split (example assertion)
+        # We expect more documents than original files due to splitting
+        original_file_count = 2
+        self.assertGreater(len(processed_docs_objects), original_file_count)
+
+        # Check if text from large doc is smaller than original, indicating splitting
+        large_doc_texts = [doc.text for doc in processed_docs_objects if doc.meta_data.get('file_path') == "large_doc.txt"]
+        self.assertTrue(any(len(text.split()) < len(SAMPLE_FILE_CONTENT_LARGE.split()) for text in large_doc_texts))
+
+
+    @patch('api.data_pipeline.OllamaDocumentProcessor')
+    @patch('api.data_pipeline.ToEmbeddings')
+    @patch('api.data_pipeline.TextSplitter')
+    def test_processing_for_fine_tuning_true(self, MockTextSplitter, MockToEmbeddings, MockOllamaProcessor):
+        # Test behavior with chunk_for_fine_tuning=True
+        db_manager = DatabaseManager()
+        db_manager.repo_paths = {
+            "save_repo_dir": TEST_REPO_PATH,
+            "save_db_file": TEST_DB_PATH
+        }
+        processed_docs_objects = db_manager.prepare_db_index(local_ollama=False, chunk_for_fine_tuning=True)
+
+        MockTextSplitter.assert_not_called()
+        MockToEmbeddings.assert_not_called()
+        MockOllamaProcessor.assert_not_called()
+        
+        # Verify that the transformation key was NOT registered
+        self.assertNotIn("split_and_embed", db_manager.db.transformers)
+
+        # Assert that documents are not split and contain full content
+        self.assertEqual(len(processed_docs_objects), 2) # Should be same number as input files
+        
+        found_large_doc = False
+        found_normal_doc = False
+        for doc in processed_docs_objects:
+            if doc.meta_data.get('file_path') == "large_doc.txt":
+                self.assertEqual(doc.text, SAMPLE_FILE_CONTENT_LARGE)
+                found_large_doc = True
+            if doc.meta_data.get('file_path') == "normal_doc.txt":
+                self.assertEqual(doc.text, SAMPLE_FILE_CONTENT_NORMAL)
+                found_normal_doc = True
+
+        self.assertTrue(found_large_doc)
+        self.assertTrue(found_normal_doc)
+
+    def test_prepare_data_pipeline_rag(self):
+        # Test that prepare_data_pipeline returns a Sequential pipeline for RAG
+        pipeline = prepare_data_pipeline(local_ollama=False, chunk_for_fine_tuning=False)
+        self.assertIsInstance(pipeline, Sequential)
+        self.assertTrue(len(pipeline.steps) > 0) # Should have steps (splitter, embedder)
+
+    def test_prepare_data_pipeline_fine_tuning(self):
+        # Test that prepare_data_pipeline returns an empty Sequential pipeline for fine-tuning
+        pipeline = prepare_data_pipeline(local_ollama=False, chunk_for_fine_tuning=True)
+        self.assertIsInstance(pipeline, Sequential)
+        self.assertEqual(len(pipeline.steps), 0) # Should be empty
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This introduces a `chunk_for_fine_tuning` parameter (a true/false setting, which is false by default) that affects how data is processed in several parts of the pipeline.

When you set `chunk_for_fine_tuning` to true:
- I will read entire files, ignoring the usual limits that are in place for creating embeddings.
- I will skip the steps where I normally split text and create embeddings.
- I will save the complete, original documents to the database.

This feature allows you to prepare datasets for fine-tuning language models that require larger, unsplit pieces of text. This can help avoid "token limit exceeded" errors that you might encounter if you were to use the RAG-specific data preparation for fine-tuning.

The standard behavior for RAG (when `chunk_for_fine_tuning` is false) is still the same, so documents will continue to be broken into smaller pieces and embedded for retrieval.

I've also added some tests to verify:
- That the correct pipeline steps are followed (either splitting/embedding or skipping them) depending on this new setting.
- That the full content of the documents is kept when the setting is true.
- That the RAG pipeline continues to work as expected.