### PR TITLE
feature/configurable-ollama-embedder

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -93,6 +93,35 @@ def load_embedder_config():
 
     return embedder_config
 
+def get_embedder_config():
+    """
+    Get the current embedder configuration.
+
+    Returns:
+        dict: The embedder configuration with model_client resolved
+    """
+    return configs.get("embedder", {})
+
+def is_ollama_embedder():
+    """
+    Check if the current embedder configuration uses OllamaClient.
+
+    Returns:
+        bool: True if using OllamaClient, False otherwise
+    """
+    embedder_config = get_embedder_config()
+    if not embedder_config:
+        return False
+
+    # Check if model_client is OllamaClient
+    model_client = embedder_config.get("model_client")
+    if model_client:
+        return model_client.__name__ == "OllamaClient"
+
+    # Fallback: check client_class string
+    client_class = embedder_config.get("client_class", "")
+    return client_class == "OllamaClient"
+
 # Load repository and file filters configuration
 def load_repo_config():
     return load_json_config("repo.json")

--- a/api/rag.py
+++ b/api/rag.py
@@ -218,15 +218,20 @@ class RAG(adal.Component):
 
         self.provider = provider
         self.model = model
-        self.local_ollama = provider == "ollama"
+
+        # Import the helper functions
+        from api.config import get_embedder_config, is_ollama_embedder
+
+        # Determine if we're using Ollama embedder based on configuration
+        self.is_ollama_embedder = is_ollama_embedder()
 
         # Initialize components
         self.memory = Memory()
 
-        if self.local_ollama:
-            embedder_config = configs["embedder_ollama"]
-        else:
-            embedder_config = configs["embedder"]
+        # Get embedder configuration
+        embedder_config = get_embedder_config()
+        if not embedder_config:
+            raise ValueError("No embedder configuration found")
 
         # --- Initialize Embedder ---
         self.embedder = adal.Embedder(
@@ -242,7 +247,9 @@ class RAG(adal.Component):
                     raise ValueError("Ollama embedder only supports a single string")
                 query = query[0]
             return self.embedder(input=query)
-        self.query_embedder = single_string_embedder
+
+        # Use single string embedder for Ollama, regular embedder for others
+        self.query_embedder = single_string_embedder if self.is_ollama_embedder else self.embedder
 
         self.initialize_db_manager()
 
@@ -402,7 +409,7 @@ IMPORTANT FORMATTING RULES:
             repo_url_or_path,
             type,
             access_token,
-            local_ollama=self.local_ollama,
+            is_ollama_embedder=self.is_ollama_embedder,
             excluded_dirs=excluded_dirs,
             excluded_files=excluded_files,
             included_dirs=included_dirs,
@@ -419,10 +426,11 @@ IMPORTANT FORMATTING RULES:
         logger.info(f"Using {len(self.transformed_docs)} documents with valid embeddings for retrieval")
 
         try:
-            retreive_embedder = self.query_embedder if self.local_ollama else self.embedder
+            # Use the appropriate embedder for retrieval
+            retrieve_embedder = self.query_embedder if self.is_ollama_embedder else self.embedder
             self.retriever = FAISSRetriever(
                 **configs["retriever"],
-                embedder=retreive_embedder,
+                embedder=retrieve_embedder,
                 documents=self.transformed_docs,
                 document_map_func=lambda doc: doc.vector,
             )


### PR DESCRIPTION
Allow `embedder.json` to be configurable to use Ollama embedding models.

e.g:
```
{
  "embedder": {
    "client_class": "OllamaClient",
    "model_kwargs": {
      "model": "nomic-embed-text"
    }
  }
}
```

Addressing issues: https://github.com/AsyncFuncAI/deepwiki-open/issues/152