### PR TITLE
improve: Resolve overlapping "Ask" button and improve input field text visibility

### DIFF
--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -604,6 +604,17 @@ const Ask: React.FC<AskProps> = ({
     }
   };
 
+  const [buttonWidth, setButtonWidth] = useState(0);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Measure button width and update state
+  useEffect(() => {
+    if (buttonRef.current) {
+      const width = buttonRef.current.offsetWidth;
+      setButtonWidth(width);
+    }
+  }, [messages.ask?.askButton, isLoading]);
+
   return (
     <div>
       <div className="p-4">
@@ -630,10 +641,12 @@ const Ask: React.FC<AskProps> = ({
               value={question}
               onChange={(e) => setQuestion(e.target.value)}
               placeholder={messages.ask?.placeholder || 'What would you like to know about this codebase?'}
-              className="block w-full rounded-md border border-[var(--border-color)] bg-[var(--input-bg)] text-[var(--foreground)] px-5 py-3.5 pr-32 text-base shadow-sm focus:border-[var(--accent-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]/30 focus:outline-none transition-all"
+              className="block w-full rounded-md border border-[var(--border-color)] bg-[var(--input-bg)] text-[var(--foreground)] px-5 py-3.5 text-base shadow-sm focus:border-[var(--accent-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]/30 focus:outline-none transition-all"
+              style={{ paddingRight: `${buttonWidth + 24}px` }}
               disabled={isLoading}
             />
             <button
+              ref={buttonRef}
               type="submit"
               disabled={isLoading || !question.trim()}
               className={`absolute right-3 top-1/2 transform -translate-y-1/2 px-4 py-2 rounded-md font-medium text-sm ${

--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -630,7 +630,7 @@ const Ask: React.FC<AskProps> = ({
               value={question}
               onChange={(e) => setQuestion(e.target.value)}
               placeholder={messages.ask?.placeholder || 'What would you like to know about this codebase?'}
-              className="block w-full rounded-md border border-[var(--border-color)] bg-[var(--input-bg)] text-[var(--foreground)] px-5 py-3.5 text-base shadow-sm focus:border-[var(--accent-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]/30 focus:outline-none transition-all"
+              className="block w-full rounded-md border border-[var(--border-color)] bg-[var(--input-bg)] text-[var(--foreground)] px-5 py-3.5 pr-32 text-base shadow-sm focus:border-[var(--accent-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]/30 focus:outline-none transition-all"
               disabled={isLoading}
             />
             <button


### PR DESCRIPTION
### Overview

This PR addresses [Issue #164](https://github.com/AsyncFuncAI/deepwiki-open/issues/164), where the "Ask" button overlaps the input field, making the end of long questions hard to read.

### Changes

- Added `pr-32` to the input field for sufficient right padding
- Preserved the position and functionality of the "Ask" button
- Improved usability and visibility when typing long questions

### Before

The text at the end of the input would be obscured by the button:

![screenshot](https://github.com/user-attachments/assets/35296bd3-c11e-4230-9b70-1bc279c99c01)

### After

The padding ensures that text is clearly visible even near the end of the input:

![image](https://github.com/user-attachments/assets/cb087fa1-d44e-4e69-a1f0-bcd0b9e2b674)


### Notes

Let me know if any adjustments are needed to fit the design standards or if further layout refinements are preferred.
