### PR TITLE
fix: Support token re-input when refreshing wiki for private repositories

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -77,6 +77,7 @@ class WikiCacheData(BaseModel):
     """
     wiki_structure: WikiStructureModel
     generated_pages: Dict[str, WikiPage]
+    repo_url: Optional[str] = None  # Add repo_url to cache
 
 class WikiCacheRequest(BaseModel):
     """
@@ -88,6 +89,7 @@ class WikiCacheRequest(BaseModel):
     language: str
     wiki_structure: WikiStructureModel
     generated_pages: Dict[str, WikiPage]
+    repo_url: Optional[str] = None  # Add repo_url to cache request
 
 class WikiExportRequest(BaseModel):
     """
@@ -389,7 +391,8 @@ async def save_wiki_cache(data: WikiCacheRequest) -> bool:
     try:
         payload = WikiCacheData(
             wiki_structure=data.wiki_structure,
-            generated_pages=data.generated_pages
+            generated_pages=data.generated_pages,
+            repo_url=data.repo_url
         )
         # Log size of data to be cached for debugging (avoid logging full content if large)
         try:

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -212,6 +212,8 @@ export default function RepoWikiPage() {
   const [exportError, setExportError] = useState<string | null>(null);
   const [originalMarkdown, setOriginalMarkdown] = useState<Record<string, string>>({});
   const [requestInProgress, setRequestInProgress] = useState(false);
+  const [currentToken, setCurrentToken] = useState(token); // Track current effective token
+  const [effectiveRepoInfo, setEffectiveRepoInfo] = useState(repoInfo); // Track effective repo info with cached data
 
   // Model selection state variables
   const [selectedProviderState, setSelectedProviderState] = useState(providerParam);
@@ -298,7 +300,7 @@ export default function RepoWikiPage() {
         console.log(`Starting content generation for page: ${page.title}`);
 
         // Get repository URL
-        const repoUrl = getRepoUrl(repoInfo);
+        const repoUrl = getRepoUrl(effectiveRepoInfo);
 
         // Create the prompt content - simplified to avoid message dialogs
  const promptContent =
@@ -392,7 +394,7 @@ Remember:
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const requestBody: Record<string, any> = {
           repo_url: repoUrl,
-          type: repoInfo.type,
+          type: effectiveRepoInfo.type,
           messages: [{
             role: 'user',
             content: promptContent
@@ -400,7 +402,7 @@ Remember:
         };
 
         // Add tokens if available
-        addTokensToRequestBody(requestBody, token, repoInfo.type, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, language, modelExcludedDirs, modelExcludedFiles);
+        addTokensToRequestBody(requestBody, currentToken, effectiveRepoInfo.type, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, language, modelExcludedDirs, modelExcludedFiles);
 
         // Use WebSocket for communication
         let content = '';
@@ -541,7 +543,7 @@ Remember:
         setLoadingMessage(undefined); // Clear specific loading message
       }
     });
-  }, [generatedPages, token, repoInfo, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, modelExcludedDirs, modelExcludedFiles, language, activeContentRequests]);
+  }, [generatedPages, currentToken, effectiveRepoInfo, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, modelExcludedDirs, modelExcludedFiles, language, activeContentRequests]);
 
   // Determine the wiki structure from repository data
   const determineWikiStructure = useCallback(async (fileTree: string, readme: string, owner: string, repo: string) => {
@@ -562,13 +564,13 @@ Remember:
       setLoadingMessage(messages.loading?.determiningStructure || 'Determining wiki structure...');
 
       // Get repository URL
-      const repoUrl = getRepoUrl(repoInfo);
+      const repoUrl = getRepoUrl(effectiveRepoInfo);
 
       // Prepare request body
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const requestBody: Record<string, any> = {
         repo_url: repoUrl,
-        type: repoInfo.type,
+        type: effectiveRepoInfo.type,
         messages: [{
           role: 'user',
 content: `Analyze this GitHub repository ${owner}/${repo} and create a wiki structure for it.
@@ -691,7 +693,7 @@ IMPORTANT:
       };
 
       // Add tokens if available
-      addTokensToRequestBody(requestBody, token, repoInfo.type, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, language, modelExcludedDirs, modelExcludedFiles);
+      addTokensToRequestBody(requestBody, currentToken, effectiveRepoInfo.type, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, language, modelExcludedDirs, modelExcludedFiles);
 
       // Use WebSocket for communication
       let responseText = '';
@@ -1008,7 +1010,7 @@ IMPORTANT:
     } finally {
       setStructureRequestInProgress(false);
     }
-  }, [generatePageContent, token, repoInfo, pagesInProgress.size, structureRequestInProgress, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, modelExcludedDirs, modelExcludedFiles, language, messages.loading, isComprehensiveView]);
+  }, [generatePageContent, currentToken, effectiveRepoInfo, pagesInProgress.size, structureRequestInProgress, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, modelExcludedDirs, modelExcludedFiles, language, messages.loading, isComprehensiveView]);
 
   // Fetch repository structure using GitHub or GitLab API
   const fetchRepositoryStructure = useCallback(async () => {
@@ -1036,9 +1038,9 @@ IMPORTANT:
       let fileTreeData = '';
       let readmeContent = '';
 
-      if (repoInfo.type === 'local' && repoInfo.localPath) {
+      if (effectiveRepoInfo.type === 'local' && effectiveRepoInfo.localPath) {
         try {
-          const response = await fetch(`/local_repo/structure?path=${encodeURIComponent(repoInfo.localPath)}`);
+          const response = await fetch(`/local_repo/structure?path=${encodeURIComponent(effectiveRepoInfo.localPath)}`);
 
           if (!response.ok) {
             const errorData = await response.text();
@@ -1051,7 +1053,7 @@ IMPORTANT:
         } catch (err) {
           throw err;
         }
-      } else if (repoInfo.type === 'github') {
+      } else if (effectiveRepoInfo.type === 'github') {
         // GitHub API approach
         // Try to get the tree data for common branch names
         let treeData = null;
@@ -1059,7 +1061,7 @@ IMPORTANT:
 
         for (const branch of ['main', 'master']) {
           const apiUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
-          const headers = createGithubHeaders(token);
+          const headers = createGithubHeaders(currentToken);
 
           console.log(`Fetching repository structure from branch: ${branch}`);
           try {
@@ -1097,7 +1099,7 @@ IMPORTANT:
 
         // Try to fetch README.md content
         try {
-          const headers = createGithubHeaders(token);
+          const headers = createGithubHeaders(currentToken);
 
           const readmeResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, {
             headers
@@ -1113,13 +1115,13 @@ IMPORTANT:
           console.warn('Could not fetch README.md, continuing with empty README', err);
         }
       }
-      else if (repoInfo.type === 'gitlab') {
+      else if (effectiveRepoInfo.type === 'gitlab') {
         // GitLab API approach
-        const projectPath = extractUrlPath(repoInfo.repoUrl ?? '') ?? `${owner}/${repo}`;
-        const projectDomain = extractUrlDomain(repoInfo.repoUrl ?? "https://gitlab.com");
+        const projectPath = extractUrlPath(effectiveRepoInfo.repoUrl ?? '') ?? `${owner}/${repo}`;
+        const projectDomain = extractUrlDomain(effectiveRepoInfo.repoUrl ?? "https://gitlab.com");
         const encodedProjectPath = encodeURIComponent(projectPath);
 
-        const headers = createGitlabHeaders(token);
+        const headers = createGitlabHeaders(currentToken);
 
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         const filesData: any[] = [];
@@ -1189,16 +1191,16 @@ IMPORTANT:
           throw err;
         }
       }
-      else if (repoInfo.type === 'bitbucket') {
+      else if (effectiveRepoInfo.type === 'bitbucket') {
         // Bitbucket API approach
-        const repoPath = extractUrlPath(repoInfo.repoUrl ?? '') ?? `${owner}/${repo}`;
+        const repoPath = extractUrlPath(effectiveRepoInfo.repoUrl ?? '') ?? `${owner}/${repo}`;
         const encodedRepoPath = encodeURIComponent(repoPath);
 
         // Try to get the file tree for common branch names
         let filesData = null;
         let apiErrorDetails = '';
         let defaultBranch = '';
-        const headers = createBitbucketHeaders(token);
+        const headers = createBitbucketHeaders(currentToken);
 
         // First get project info to determine default branch
         const projectInfoUrl = `https://api.bitbucket.org/2.0/repositories/${encodedRepoPath}`;
@@ -1252,7 +1254,7 @@ IMPORTANT:
 
         // Try to fetch README.md content
         try {
-          const headers = createBitbucketHeaders(token);
+          const headers = createBitbucketHeaders(currentToken);
 
           const readmeResponse = await fetch(`https://api.bitbucket.org/2.0/repositories/${encodedRepoPath}/src/${defaultBranch}/README.md`, {
             headers
@@ -1280,7 +1282,7 @@ IMPORTANT:
       // Reset the request in progress flag
       setRequestInProgress(false);
     }
-  }, [owner, repo, determineWikiStructure, token, repoInfo, requestInProgress, messages.loading]);
+  }, [owner, repo, determineWikiStructure, currentToken, effectiveRepoInfo, requestInProgress, messages.loading]);
 
   // Function to export wiki content
   const exportWiki = useCallback(async (format: 'markdown' | 'json') => {
@@ -1305,7 +1307,7 @@ IMPORTANT:
       });
 
       // Get repository URL
-      const repoUrl = getRepoUrl(repoInfo);
+      const repoUrl = getRepoUrl(effectiveRepoInfo);
 
       // Make API call to export wiki
       const response = await fetch(`/export/wiki`, {
@@ -1315,7 +1317,7 @@ IMPORTANT:
         },
         body: JSON.stringify({
           repo_url: repoUrl,
-          type: repoInfo.type,
+          type: effectiveRepoInfo.type,
           pages: pagesToExport,
           format
         })
@@ -1328,7 +1330,7 @@ IMPORTANT:
 
       // Get the filename from the Content-Disposition header if available
       const contentDisposition = response.headers.get('Content-Disposition');
-      let filename = `${repoInfo.repo}_wiki.${format === 'markdown' ? 'md' : 'json'}`;
+      let filename = `${effectiveRepoInfo.repo}_wiki.${format === 'markdown' ? 'md' : 'json'}`;
 
       if (contentDisposition) {
         const filenameMatch = contentDisposition.match(/filename=(.+)/);
@@ -1356,20 +1358,20 @@ IMPORTANT:
       setIsExporting(false);
       setLoadingMessage(undefined);
     }
-  }, [wikiStructure, generatedPages, repoInfo, language]);
+  }, [wikiStructure, generatedPages, effectiveRepoInfo, language]);
 
   // No longer needed as we use the modal directly
 
-  const confirmRefresh = useCallback(async () => {
+  const confirmRefresh = useCallback(async (newToken?: string) => {
     setShowModelOptions(false);
     setLoadingMessage(messages.loading?.clearingCache || 'Clearing server cache...');
     setIsLoading(true); // Show loading indicator immediately
 
     try {
       const params = new URLSearchParams({
-        owner: repoInfo.owner,
-        repo: repoInfo.repo,
-        repo_type: repoInfo.type,
+        owner: effectiveRepoInfo.owner,
+        repo: effectiveRepoInfo.repo,
+        repo_type: effectiveRepoInfo.type,
         language: language,
         provider: selectedProviderState,
         model: selectedModelState,
@@ -1405,11 +1407,21 @@ IMPORTANT:
       // setError(\`Error clearing cache: ${err instanceof Error ? err.message : String(err)}. Trying to refresh...\`);
     }
 
+    // Update token if provided
+    if (newToken) {
+      // Update current token state
+      setCurrentToken(newToken);
+      // Update the URL parameters to include the new token
+      const currentUrl = new URL(window.location.href);
+      currentUrl.searchParams.set('token', newToken);
+      window.history.replaceState({}, '', currentUrl.toString());
+    }
+
     // Proceed with the rest of the refresh logic
     console.log('Refreshing wiki. Server cache will be overwritten upon new generation if not cleared.');
 
     // Clear the localStorage cache (if any remnants or if it was used before this change)
-    const localStorageCacheKey = getCacheKey(repoInfo.owner, repoInfo.repo, repoInfo.type, language, isComprehensiveView);
+    const localStorageCacheKey = getCacheKey(effectiveRepoInfo.owner, effectiveRepoInfo.repo, effectiveRepoInfo.type, language, isComprehensiveView);
     localStorage.removeItem(localStorageCacheKey);
 
     // Reset cache loaded flag
@@ -1439,7 +1451,7 @@ IMPORTANT:
     // For now, we rely on the standard loadData flow initiated by resetting effectRan and dependencies.
     // This will re-trigger the main data loading useEffect.
     // No direct call to fetchRepositoryStructure here, let the useEffect handle it based on effectRan.current = false.
-  }, [repoInfo.owner, repoInfo.repo, repoInfo.type, language, messages.loading, activeContentRequests, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, modelExcludedDirs, modelExcludedFiles, isComprehensiveView]);
+  }, [effectiveRepoInfo, language, messages.loading, activeContentRequests, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, modelExcludedDirs, modelExcludedFiles, isComprehensiveView]);
 
   // Start wiki generation when component mounts
   useEffect(() => {
@@ -1451,9 +1463,9 @@ IMPORTANT:
         setLoadingMessage(messages.loading?.fetchingCache || 'Checking for cached wiki...');
         try {
           const params = new URLSearchParams({
-            owner: repoInfo.owner,
-            repo: repoInfo.repo,
-            repo_type: repoInfo.type,
+            owner: effectiveRepoInfo.owner,
+            repo: effectiveRepoInfo.repo,
+            repo_type: effectiveRepoInfo.type,
             language: language,
             comprehensive: isComprehensiveView.toString(),
           });
@@ -1463,6 +1475,14 @@ IMPORTANT:
             const cachedData = await response.json(); // Returns null if no cache
             if (cachedData && cachedData.wiki_structure && cachedData.generated_pages && Object.keys(cachedData.generated_pages).length > 0) {
               console.log('Using server-cached wiki data');
+
+              // Update repoInfo with cached repo_url if not provided in URL
+              let updatedRepoInfo = effectiveRepoInfo;
+              if (cachedData.repo_url && !effectiveRepoInfo.repoUrl) {
+                updatedRepoInfo = { ...effectiveRepoInfo, repoUrl: cachedData.repo_url };
+                setEffectiveRepoInfo(updatedRepoInfo); // Update effective repo info state
+                console.log('Using cached repo_url:', cachedData.repo_url);
+              }
 
               // Ensure the cached structure has sections and rootSections
               const cachedStructure = {
@@ -1612,7 +1632,7 @@ IMPORTANT:
 
     // Clean up function for this effect is not strictly necessary for loadData,
     // but keeping the main unmount cleanup in the other useEffect
-  }, [repoInfo.owner, repoInfo.repo, repoInfo.type, language, fetchRepositoryStructure, messages.loading?.fetchingCache, isComprehensiveView]);
+  }, [effectiveRepoInfo.owner, effectiveRepoInfo.repo, effectiveRepoInfo.type, language, fetchRepositoryStructure, messages.loading?.fetchingCache, isComprehensiveView]);
 
   // Save wiki to server-side cache when generation is complete
   useEffect(() => {
@@ -1639,13 +1659,14 @@ IMPORTANT:
             };
 
             const dataToCache = {
-              owner: repoInfo.owner,
-              repo: repoInfo.repo,
-              repo_type: repoInfo.type,
+              owner: effectiveRepoInfo.owner,
+              repo: effectiveRepoInfo.repo,
+              repo_type: effectiveRepoInfo.type,
               language: language,
               comprehensive: isComprehensiveView,
               wiki_structure: structureToCache,
-              generated_pages: generatedPages
+              generated_pages: generatedPages,
+              repo_url: effectiveRepoInfo.repoUrl || repoUrl || undefined // Include repo_url in cache
             };
             const response = await fetch(`/api/wiki_cache`, {
               method: 'POST',
@@ -1668,7 +1689,7 @@ IMPORTANT:
     };
 
     saveCache();
-  }, [isLoading, error, wikiStructure, generatedPages, repoInfo.owner, repoInfo.repo, repoInfo.type, language, isComprehensiveView]);
+  }, [isLoading, error, wikiStructure, generatedPages, effectiveRepoInfo.owner, effectiveRepoInfo.repo, effectiveRepoInfo.type, language, isComprehensiveView]);
 
   const handlePageSelect = (pageId: string) => {
     if (currentPageId != pageId) {
@@ -1784,27 +1805,27 @@ IMPORTANT:
 
               {/* Display repository info */}
               <div className="text-xs text-[var(--muted)] mb-5 flex items-center">
-                {repoInfo.type === 'local' ? (
+                {effectiveRepoInfo.type === 'local' ? (
                   <div className="flex items-center">
                     <FaFolder className="mr-2" />
-                    <span className="break-all">{repoInfo.localPath}</span>
+                    <span className="break-all">{effectiveRepoInfo.localPath}</span>
                   </div>
                 ) : (
                   <>
-                    {repoInfo.type === 'github' ? (
+                    {effectiveRepoInfo.type === 'github' ? (
                       <FaGithub className="mr-2" />
-                    ) : repoInfo.type === 'gitlab' ? (
+                    ) : effectiveRepoInfo.type === 'gitlab' ? (
                       <FaGitlab className="mr-2" />
                     ) : (
                       <FaBitbucket className="mr-2" />
                     )}
                     <a
-                      href={repoInfo.repoUrl ?? ''}
+                      href={effectiveRepoInfo.repoUrl ?? ''}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="hover:text-[var(--accent-primary)] transition-colors border-b border-[var(--border-color)] hover:border-[var(--accent-primary)]"
                     >
-                      {repoInfo.owner}/{repoInfo.repo}
+                      {effectiveRepoInfo.owner}/{effectiveRepoInfo.repo}
                     </a>
                   </>
                 )}
@@ -1968,7 +1989,7 @@ IMPORTANT:
           </div>
           <div className="flex-1 overflow-y-auto p-4">
             <Ask
-              repoInfo={repoInfo}
+              repoInfo={effectiveRepoInfo}
               provider={selectedProviderState}
               model={selectedModelState}
               isCustomModel={isCustomSelectedModelState}
@@ -2000,6 +2021,8 @@ IMPORTANT:
         setExcludedFiles={setModelExcludedFiles}
         onApply={confirmRefresh}
         showWikiType={true}
+        showTokenInput={effectiveRepoInfo.type !== 'local' && !currentToken} // Show token input if not local and no current token
+        repositoryType={effectiveRepoInfo.type as 'github' | 'gitlab' | 'bitbucket'}
       />
     </div>
   );

--- a/src/components/ConfigurationModal.tsx
+++ b/src/components/ConfigurationModal.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import UserSelector from './UserSelector';
+import TokenInput from './TokenInput';
+
 interface ConfigurationModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -220,80 +222,16 @@ export default function ConfigurationModal({
               />
             </div>
 
-            {/* Access token section */}
-            <div className="mb-4">
-              <button
-                type="button"
-                onClick={() => setShowTokenSection(!showTokenSection)}
-                className="text-sm text-[var(--accent-primary)] hover:text-[var(--highlight)] flex items-center transition-colors border-b border-[var(--border-color)] hover:border-[var(--accent-primary)] pb-0.5 mb-2"
-              >
-                {showTokenSection ? t.form?.hideTokens || 'Hide Access Tokens' : t.form?.addTokens || 'Add Access Tokens for Private Repositories'}
-              </button>
-
-              {showTokenSection && (
-                <div className="mt-2 p-4 bg-[var(--background)]/50 rounded-md border border-[var(--border-color)]">
-                  <div className="mb-3">
-                    <label className="block text-xs font-medium text-[var(--foreground)] mb-2">
-                      {t.form?.selectPlatform || 'Select Platform'}
-                    </label>
-                    <div className="flex gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setSelectedPlatform('github')}
-                        className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${selectedPlatform === 'github'
-                          ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
-                          : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
-                          }`}
-                      >
-                        <span className="text-sm">GitHub</span>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setSelectedPlatform('gitlab')}
-                        className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${selectedPlatform === 'gitlab'
-                          ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
-                          : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
-                          }`}
-                      >
-                        <span className="text-sm">GitLab</span>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setSelectedPlatform('bitbucket')}
-                        className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${selectedPlatform === 'bitbucket'
-                          ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
-                          : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
-                          }`}
-                      >
-                        <span className="text-sm">Bitbucket</span>
-                      </button>
-                    </div>
-                  </div>
-
-                  <div>
-                    <label htmlFor="access-token" className="block text-xs font-medium text-[var(--foreground)] mb-2">
-                      {t.form?.personalAccessToken || 'Personal Access Token'}
-                    </label>
-                    <input
-                      id="access-token"
-                      type="password"
-                      value={accessToken}
-                      onChange={(e) => setAccessToken(e.target.value)}
-                      placeholder={t.form?.tokenPlaceholder || 'Enter your access token'}
-                      className="input-japanese block w-full px-3 py-2 rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)] text-sm"
-                    />
-                    <div className="flex items-center mt-2 text-xs text-[var(--muted)]">
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1 text-[var(--muted)]"
-                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      {t.form?.tokenSecurityNote || 'Your token is stored locally and never sent to our servers.'}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
+            {/* Access token section using TokenInput component */}
+            <TokenInput
+              selectedPlatform={selectedPlatform}
+              setSelectedPlatform={setSelectedPlatform}
+              accessToken={accessToken}
+              setAccessToken={setAccessToken}
+              showTokenSection={showTokenSection}
+              onToggleTokenSection={() => setShowTokenSection(!showTokenSection)}
+              allowPlatformChange={true}
+            />
           </div>
 
           {/* Modal footer */}

--- a/src/components/ModelSelectionModal.tsx
+++ b/src/components/ModelSelectionModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import UserSelector from './UserSelector';
 import WikiTypeSelector from './WikiTypeSelector';
+import TokenInput from './TokenInput';
 
 interface ModelSelectionModalProps {
   isOpen: boolean;
@@ -16,7 +17,7 @@ interface ModelSelectionModalProps {
   setIsCustomModel: (value: boolean) => void;
   customModel: string;
   setCustomModel: (value: string) => void;
-  onApply: () => void;
+  onApply: (token?: string) => void;
 
   // Wiki type options
   isComprehensiveView: boolean;
@@ -33,6 +34,10 @@ interface ModelSelectionModalProps {
   setIncludedFiles?: (value: string) => void;
   showFileFilters?: boolean;
   showWikiType: boolean;
+  
+  // Token input for refresh
+  showTokenInput?: boolean;
+  repositoryType?: 'github' | 'gitlab' | 'bitbucket';
 }
 
 export default function ModelSelectionModal({
@@ -59,6 +64,8 @@ export default function ModelSelectionModal({
   setIncludedFiles,
   showFileFilters = false,
   showWikiType = true,
+  showTokenInput = false,
+  repositoryType = 'github',
 }: ModelSelectionModalProps) {
   const { messages: t } = useLanguage();
 
@@ -72,6 +79,11 @@ export default function ModelSelectionModal({
   const [localExcludedFiles, setLocalExcludedFiles] = useState(excludedFiles);
   const [localIncludedDirs, setLocalIncludedDirs] = useState(includedDirs);
   const [localIncludedFiles, setLocalIncludedFiles] = useState(includedFiles);
+  
+  // Token input state
+  const [localAccessToken, setLocalAccessToken] = useState('');
+  const [localSelectedPlatform, setLocalSelectedPlatform] = useState<'github' | 'gitlab' | 'bitbucket'>(repositoryType);
+  const [showTokenSection, setShowTokenSection] = useState(showTokenInput);
 
   // Reset local state when modal is opened
   useEffect(() => {
@@ -85,8 +97,11 @@ export default function ModelSelectionModal({
       setLocalExcludedFiles(excludedFiles);
       setLocalIncludedDirs(includedDirs);
       setLocalIncludedFiles(includedFiles);
+      setLocalSelectedPlatform(repositoryType);
+      setLocalAccessToken('');
+      setShowTokenSection(showTokenInput);
     }
-  }, [isOpen, provider, model, isCustomModel, customModel, isComprehensiveView, excludedDirs, excludedFiles, includedDirs, includedFiles]);
+  }, [isOpen, provider, model, isCustomModel, customModel, isComprehensiveView, excludedDirs, excludedFiles, includedDirs, includedFiles, repositoryType, showTokenInput]);
 
   // Handler for applying changes
   const handleApply = () => {
@@ -99,7 +114,13 @@ export default function ModelSelectionModal({
     if (setExcludedFiles) setExcludedFiles(localExcludedFiles);
     if (setIncludedDirs) setIncludedDirs(localIncludedDirs);
     if (setIncludedFiles) setIncludedFiles(localIncludedFiles);
-    onApply();
+    
+    // Pass token to onApply if needed
+    if (showTokenInput) {
+      onApply(localAccessToken);
+    } else {
+      onApply();
+    }
     onClose();
   };
 
@@ -158,6 +179,22 @@ export default function ModelSelectionModal({
               includedFiles={localIncludedFiles}
               setIncludedFiles={showFileFilters ? (value: string) => setLocalIncludedFiles(value) : undefined}
             />
+
+            {/* Token Input Section for refresh */}
+            {showTokenInput && (
+              <>
+                <div className="my-4 border-t border-[var(--border-color)]/30"></div>
+                <TokenInput
+                  selectedPlatform={localSelectedPlatform}
+                  setSelectedPlatform={setLocalSelectedPlatform}
+                  accessToken={localAccessToken}
+                  setAccessToken={setLocalAccessToken}
+                  showTokenSection={showTokenSection}
+                  onToggleTokenSection={() => setShowTokenSection(!showTokenSection)}
+                  allowPlatformChange={false} // Don't allow platform change during refresh
+                />
+              </>
+            )}
           </div>
 
           {/* Modal footer */}

--- a/src/components/ProcessedProjects.tsx
+++ b/src/components/ProcessedProjects.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
-import { FaSearch, FaTimes, FaTh, FaList } from 'react-icons/fa';
+import { FaTimes, FaTh, FaList } from 'react-icons/fa';
 
 // Interface should match the structure from the API
 interface ProcessedProject {
@@ -19,7 +19,7 @@ interface ProcessedProjectsProps {
   showHeader?: boolean;
   maxItems?: number;
   className?: string;
-  messages?: any; // Translation messages
+  messages?: Record<string, Record<string, string>>; // Translation messages with proper typing
 }
 
 export default function ProcessedProjects({ 

--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -24,6 +24,8 @@ export default function TokenInput({
 }: TokenInputProps) {
   const { messages: t } = useLanguage();
 
+  const platformName = selectedPlatform.charAt(0).toUpperCase() + selectedPlatform.slice(1);
+
   return (
     <div className="mb-4">
       {onToggleTokenSection && (
@@ -80,14 +82,14 @@ export default function TokenInput({
 
           <div>
             <label htmlFor="access-token" className="block text-xs font-medium text-[var(--foreground)] mb-2">
-              {t.form?.personalAccessToken || 'Personal Access Token'}
+              {(t.form?.personalAccessToken || 'Personal Access Token').replace('{platform}', platformName)}
             </label>
             <input
               id="access-token"
               type="password"
               value={accessToken}
               onChange={(e) => setAccessToken(e.target.value)}
-              placeholder={t.form?.tokenPlaceholder || 'Enter your access token'}
+              placeholder={(t.form?.tokenPlaceholder || 'Enter your access token').replace('{platform}', platformName)}
               className="input-japanese block w-full px-3 py-2 rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)] text-sm"
             />
             <div className="flex items-center mt-2 text-xs text-[var(--muted)]">

--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React from 'react';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+interface TokenInputProps {
+  selectedPlatform: 'github' | 'gitlab' | 'bitbucket';
+  setSelectedPlatform: (value: 'github' | 'gitlab' | 'bitbucket') => void;
+  accessToken: string;
+  setAccessToken: (value: string) => void;
+  showTokenSection?: boolean;
+  onToggleTokenSection?: () => void;
+  allowPlatformChange?: boolean;
+}
+
+export default function TokenInput({
+  selectedPlatform,
+  setSelectedPlatform,
+  accessToken,
+  setAccessToken,
+  showTokenSection = true,
+  onToggleTokenSection,
+  allowPlatformChange = true
+}: TokenInputProps) {
+  const { messages: t } = useLanguage();
+
+  return (
+    <div className="mb-4">
+      {onToggleTokenSection && (
+        <button
+          type="button"
+          onClick={onToggleTokenSection}
+          className="text-sm text-[var(--accent-primary)] hover:text-[var(--highlight)] flex items-center transition-colors border-b border-[var(--border-color)] hover:border-[var(--accent-primary)] pb-0.5 mb-2"
+        >
+          {showTokenSection ? t.form?.hideTokens || 'Hide Access Tokens' : t.form?.addTokens || 'Add Access Tokens for Private Repositories'}
+        </button>
+      )}
+
+      {showTokenSection && (
+        <div className="mt-2 p-4 bg-[var(--background)]/50 rounded-md border border-[var(--border-color)]">
+          {allowPlatformChange && (
+            <div className="mb-3">
+              <label className="block text-xs font-medium text-[var(--foreground)] mb-2">
+                {t.form?.selectPlatform || 'Select Platform'}
+              </label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setSelectedPlatform('github')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${selectedPlatform === 'github'
+                    ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
+                    : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
+                    }`}
+                >
+                  <span className="text-sm">GitHub</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSelectedPlatform('gitlab')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${selectedPlatform === 'gitlab'
+                    ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
+                    : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
+                    }`}
+                >
+                  <span className="text-sm">GitLab</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSelectedPlatform('bitbucket')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${selectedPlatform === 'bitbucket'
+                    ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
+                    : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
+                    }`}
+                >
+                  <span className="text-sm">Bitbucket</span>
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="access-token" className="block text-xs font-medium text-[var(--foreground)] mb-2">
+              {t.form?.personalAccessToken || 'Personal Access Token'}
+            </label>
+            <input
+              id="access-token"
+              type="password"
+              value={accessToken}
+              onChange={(e) => setAccessToken(e.target.value)}
+              placeholder={t.form?.tokenPlaceholder || 'Enter your access token'}
+              className="input-japanese block w-full px-3 py-2 rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)] text-sm"
+            />
+            <div className="flex items-center mt-2 text-xs text-[var(--muted)]">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1 text-[var(--muted)]"
+                fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              {t.form?.tokenSecurityNote || 'Your token is stored locally and never sent to our servers.'}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+} 


### PR DESCRIPTION
## 🐛 Problem Description

When users create a wiki for private repositories and then navigate back to the home page to access the cached wiki, clicking "Refresh Wiki" would fail with a 404 error:
```
GitLab project info error: Status 404, Response: {"message":"404 Project Not Found"}
```

**Root Causes:**
1. **Missing repo_url in cache**: The backend cache didn't store the complete repository URL, causing fallback to `gitlab.com` instead of custom GitLab instances
2. **No token re-input mechanism**: When accessing cached wikis, tokens weren't preserved, but users had no way to re-enter them during refresh

## ✅ Solution

### Backend Changes
- **Enhanced cache models** to store `repo_url` in `WikiCacheData` and `WikiCacheRequest`
- **Preserve repository context** for proper API calls to custom GitLab/GitHub instances

### Frontend Changes  
- **Created shared `TokenInput` component** for consistent token input UI across modals
- **Added token re-input to refresh flow** via enhanced `ModelSelectionModal`
- **Implemented `effectiveRepoInfo` state** to track current repository info including cached data
- **Refactored token handling** with `currentToken` state for proper API authentication

## 🔧 Technical Details

**Files Modified:**
- `api/api.py` - Added `repo_url` field to cache models
- `src/components/TokenInput.tsx` - New shared component (106 lines)
- `src/components/ConfigurationModal.tsx` - Refactored to use shared component (-86 lines)
- `src/components/ModelSelectionModal.tsx` - Added token input support (+43 lines)
- `src/app/[owner]/[repo]/page.tsx` - Implemented `effectiveRepoInfo` logic (119 lines modified)
- `src/components/ProcessedProjects.tsx` - Minor type fixes (-4 lines)

**Key Architecture Changes:**
- `repoInfo` → `effectiveRepoInfo`: Ensures cached repository data is used consistently
- `token` → `currentToken`: Tracks effective authentication token including user re-input
- Shared `TokenInput`: Eliminates code duplication between configuration and refresh flows

## 🧪 Testing Steps

1. **Create wiki for private repository**:
   ```
   https://git.example.com/owner/private-repo
   ```
   with access token

2. **Navigate back to home page** and click the cached wiki

3. **Click "Refresh Wiki"** button

4. **Verify token input appears** when no token is available

5. **Enter new token** and confirm refresh works with correct GitLab instance

6. **Verify no more 404 errors** from wrong GitLab domain
