### PR TITLE
Add GITHUB_API_BASE_URL environment variable

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -443,7 +443,8 @@ def get_github_file_content(repo_url: str, file_path: str, access_token: str = N
 
         # Use GitHub API to get file content
         # The API endpoint for getting file content is: /repos/{owner}/{repo}/contents/{path}
-        api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{file_path}"
+        api_base_url = os.getenv("GITHUB_API_BASE_URL", "https://api.github.com")
+        api_url = f"https://{api_base_url}/repos/{owner}/{repo}/contents/{file_path}"
 
         # Prepare curl command with authentication if token is provided
         curl_cmd = ["curl", "-s"]

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -1057,8 +1057,9 @@ IMPORTANT:
         let treeData = null;
         let apiErrorDetails = '';
 
+        const apiBaseUrl = process.env.GITHUB_API_BASE_URL || 'https://api.github.com';
         for (const branch of ['main', 'master']) {
-          const apiUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
+          const apiUrl = `${apiBaseUrl}/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
           const headers = createGithubHeaders(token);
 
           console.log(`Fetching repository structure from branch: ${branch}`);
@@ -1099,7 +1100,7 @@ IMPORTANT:
         try {
           const headers = createGithubHeaders(token);
 
-          const readmeResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, {
+          const readmeResponse = await fetch(`${apiBaseUrl}/repos/${owner}/${repo}/readme`, {
             headers
           });
 


### PR DESCRIPTION
Enable integration with self-hosted GitHub Enterprise servers by allowing custom API base URL configuration through environment variable.

https://github.com/AsyncFuncAI/deepwiki-open/issues/96