### PR TITLE
feat - support repos with self-signed ca-s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ yarn-error.log*
 next-env.d.ts
 
 .idea/
+
+# ignore adding self-signed certs
+certs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1-labs
 
-FROM node:20-alpine AS node_base
+# Build argument for custom certificates directory
+ARG CUSTOM_CERT_DIR="certs"
+
+FROM node:current-alpine3.22 AS node_base
 
 FROM node_base AS node_deps
 WORKDIR /app
@@ -37,6 +40,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     gnupg \
     git \
+    ca-certificates \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
@@ -44,6 +48,18 @@ RUN apt-get update && apt-get install -y \
     && apt-get install -y nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Update certificates if custom ones were provided and copied successfully
+RUN if [ -n "${CUSTOM_CERT_DIR}" ]; then \
+        mkdir -p /usr/local/share/ca-certificates && \
+        if [ -d "${CUSTOM_CERT_DIR}" ]; then \
+            cp -r ${CUSTOM_CERT_DIR}/* /usr/local/share/ca-certificates/ 2>/dev/null || true; \
+            update-ca-certificates; \
+            echo "Custom certificates installed successfully."; \
+        else \
+            echo "Warning: ${CUSTOM_CERT_DIR} not found. Skipping certificate installation."; \
+        fi \
+    fi
 
 ENV PATH="/opt/venv/bin:$PATH"
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ If `DEEPWIKI_AUTH_MODE` is not set or is set to `false` (or any other value than
 
 You can use Docker to run DeepWiki:
 
+#### Running the Container
+
 ```bash
 # Pull the image from GitHub Container Registry
 docker pull ghcr.io/asyncfuncai/deepwiki-open:latest
@@ -398,6 +400,22 @@ docker run -p 8001:8001 -p 3000:3000 \
   -e OPENROUTER_API_KEY=your_openrouter_api_key \
   -e OLLAMA_HOST=your_ollama_host \
   deepwiki-open
+```
+
+#### Using Self-Signed Certificates in Docker
+
+If you're in an environment that uses self-signed certificates, you can include them in the Docker build:
+
+1. Create a directory for your certificates (default is `certs` in your project root)
+2. Copy your `.crt` or `.pem` certificate files into this directory
+3. Build the Docker image:
+
+```bash
+# Build with default certificates directory (certs)
+docker build .
+
+# Or build with a custom certificates directory
+docker build --build-arg CUSTOM_CERT_DIR=my-custom-certs .
 ```
 
 ### API Server Details


### PR DESCRIPTION
If you have a system which has it's own signed certificates, you need to include those in the docker image. This introduces this feature (over just mounting the host) and should help with deployments where self-signed CAs are more common.