### PR TITLE
fix: Corrected non-default port extraction for self-hosted gitlab

### DIFF
--- a/src/utils/urlDecoder.tsx
+++ b/src/utils/urlDecoder.tsx
@@ -2,7 +2,7 @@ export function extractUrlDomain(input: string): string | null {
     try {
         const normalizedInput = input.startsWith('http') ? input : `https://${input}`;
         const url = new URL(normalizedInput);
-        return `${url.protocol}//${url.hostname}`; // Inclut le protocole et le domaine
+        return `${url.protocol}//${url.hostname}${url.port ? ':' + url.port : ''}`; // Inclut le protocole et le domaine
     } catch {
         return null; // Not a valid URL
     }


### PR DESCRIPTION
Issue #26 

In the current URL domain extraction logic, the `extractUrlDomain` function failed to correctly include the port number in the returned domain string when processing URLs that contain non-standard (non-default) ports. This led to incomplete or inaccurate domain information in scenarios such as self-hosted GitLab instances, where they might be running on ports other than 80 or 443.