### PR TITLE
fix: prevent infinite logging loop caused by log file changes

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -44,6 +44,11 @@ if __name__ == "__main__":
     # Run the FastAPI app with uvicorn
     # Disable reload in production/Docker environment
     is_development = os.environ.get("NODE_ENV") != "production"
+    
+    if is_development:
+        # Prevent infinite logging loop caused by file changes triggering log writes
+        logging.getLogger("watchfiles.main").setLevel(logging.WARNING)
+
     uvicorn.run(
         "api.api:app",
         host="0.0.0.0",


### PR DESCRIPTION
When running the app in debug mode via python -m api.main, the watchfiles module detects changes in the api folder and triggers reloads. However, since logs are written to files within the same folder, each log write causes a file change, resulting in an infinite loop like:

2025-06-12 09:39:40,300 - INFO - watchfiles.main - main.py:308 - 1 change detected
2025-06-12 09:39:40,651 - INFO - watchfiles.main - main.py:308 - 1 change detected
...
To prevent this, we set the log level of watchfiles.main to WARNING, effectively suppressing its own info-level logs that were triggering further reloads.