### PR TITLE
fix: remove unsupported `top_p` parameter for OpenAI o3 model

### DIFF
--- a/api/config/generator.json
+++ b/api/config/generator.json
@@ -39,8 +39,7 @@
           "top_p": 0.8
         },
         "o3": {
-          "temperature": 0.7,
-          "top_p": 0.8
+          "temperature": 1.0
         },
         "o4-mini": {
           "temperature": 0.7,
@@ -69,8 +68,7 @@
           "top_p": 0.8
         },
         "openai/o3": {
-          "temperature": 0.7,
-          "top_p": 0.8
+          "temperature": 1.0
         },
         "openai/o4-mini": {
           "temperature": 0.7,
@@ -169,3 +167,4 @@
     }
   }
 }
+

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -456,9 +456,11 @@ This file contains...
             model_kwargs = {
                 "model": request.model,
                 "stream": True,
-                "temperature": model_config["temperature"],
-                "top_p": model_config["top_p"]
+                "temperature": model_config["temperature"]
             }
+            # Only add top_p if it exists in the model config
+            if "top_p" in model_config:
+                model_kwargs["top_p"] = model_config["top_p"]
 
             api_kwargs = model.convert_inputs_to_api_kwargs(
                 input=prompt,
@@ -478,9 +480,11 @@ This file contains...
             model_kwargs = {
                 "model": request.model,
                 "stream": True,
-                "temperature": model_config["temperature"],
-                "top_p": model_config["top_p"]
+                "temperature": model_config["temperature"]
             }
+            # Only add top_p if it exists in the model config
+            if "top_p" in model_config:
+                model_kwargs["top_p"] = model_config["top_p"]
 
             api_kwargs = model.convert_inputs_to_api_kwargs(
                 input=prompt,

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -458,9 +458,11 @@ This file contains...
             model_kwargs = {
                 "model": request.model,
                 "stream": True,
-                "temperature": model_config["temperature"],
-                "top_p": model_config["top_p"]
+                "temperature": model_config["temperature"]
             }
+            # Only add top_p if it exists in the model config
+            if "top_p" in model_config:
+                model_kwargs["top_p"] = model_config["top_p"]
 
             api_kwargs = model.convert_inputs_to_api_kwargs(
                 input=prompt,
@@ -480,9 +482,11 @@ This file contains...
             model_kwargs = {
                 "model": request.model,
                 "stream": True,
-                "temperature": model_config["temperature"],
-                "top_p": model_config["top_p"]
+                "temperature": model_config["temperature"]
             }
+            # Only add top_p if it exists in the model config
+            if "top_p" in model_config:
+                model_kwargs["top_p"] = model_config["top_p"]
 
             api_kwargs = model.convert_inputs_to_api_kwargs(
                 input=prompt,


### PR DESCRIPTION
OpenAI's o3 model doesn't support the `top_p` parameter, causing API errors. This PR removes `top_p` from o3's configuration and updates the code to conditionally include parameters only when they exist in the model config.

Also adjusted o3's temperature to 1.0 (the only supported value for this model).