### PR TITLE
feat: update github api with Enterprise endpoint support

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -92,7 +92,8 @@ def download_repo(repo_url: str, local_path: str, type: str = "github", access_t
             parsed = urlparse(repo_url)
             # Determine the repository type and format the URL accordingly
             if type == "github":
-                # Format: https://{token}@github.com/owner/repo.git
+                # Format: https://{token}@{domain}/owner/repo.git
+                # Works for both github.com and enterprise GitHub domains
                 clone_url = urlunparse((parsed.scheme, f"{access_token}@{parsed.netloc}", parsed.path, '', '', ''))
             elif type == "gitlab":
                 # Format: https://oauth2:{token}@gitlab.com/owner/repo.git
@@ -414,9 +415,11 @@ def transform_documents_and_save_to_db(
 def get_github_file_content(repo_url: str, file_path: str, access_token: str = None) -> str:
     """
     Retrieves the content of a file from a GitHub repository using the GitHub API.
-
+    Supports both public GitHub (github.com) and GitHub Enterprise (custom domains).
+    
     Args:
-        repo_url (str): The URL of the GitHub repository (e.g., "https://github.com/username/repo")
+        repo_url (str): The URL of the GitHub repository 
+                       (e.g., "https://github.com/username/repo" or "https://github.company.com/username/repo")
         file_path (str): The path to the file within the repository (e.g., "src/main.py")
         access_token (str, optional): GitHub personal access token for private repositories
 
@@ -427,20 +430,30 @@ def get_github_file_content(repo_url: str, file_path: str, access_token: str = N
         ValueError: If the file cannot be fetched or if the URL is not a valid GitHub URL
     """
     try:
-        # Extract owner and repo name from GitHub URL
-        if not (repo_url.startswith("https://github.com/") or repo_url.startswith("http://github.com/")):
+        # Parse the repository URL to support both github.com and enterprise GitHub
+        parsed_url = urlparse(repo_url)
+        if not parsed_url.scheme or not parsed_url.netloc:
             raise ValueError("Not a valid GitHub repository URL")
 
-        parts = repo_url.rstrip('/').split('/')
-        if len(parts) < 5:
-            raise ValueError("Invalid GitHub URL format")
+        # Check if it's a GitHub-like URL structure
+        path_parts = parsed_url.path.strip('/').split('/')
+        if len(path_parts) < 2:
+            raise ValueError("Invalid GitHub URL format - expected format: https://domain/owner/repo")
 
-        owner = parts[-2]
-        repo = parts[-1].replace(".git", "")
+        owner = path_parts[-2]
+        repo = path_parts[-1].replace(".git", "")
 
+        # Determine the API base URL
+        if parsed_url.netloc == "github.com":
+            # Public GitHub
+            api_base = "https://api.github.com"
+        else:
+            # GitHub Enterprise - API is typically at https://domain/api/v3/
+            api_base = f"{parsed_url.scheme}://{parsed_url.netloc}/api/v3"
+        
         # Use GitHub API to get file content
         # The API endpoint for getting file content is: /repos/{owner}/{repo}/contents/{path}
-        api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{file_path}"
+        api_url = f"{api_base}/repos/{owner}/{repo}/contents/{file_path}"
 
         # Fetch file content from GitHub API
         headers = {}

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -1120,8 +1120,33 @@ IMPORTANT:
         let treeData = null;
         let apiErrorDetails = '';
 
+        // Determine the GitHub API base URL based on the repository URL
+        const getGithubApiUrl = (repoUrl: string | null): string => {
+          if (!repoUrl) {
+            return 'https://api.github.com'; // Default to public GitHub
+          }
+          
+          try {
+            const url = new URL(repoUrl);
+            const hostname = url.hostname;
+            
+            // If it's the public GitHub, use the standard API URL
+            if (hostname === 'github.com') {
+              return 'https://api.github.com';
+            }
+            
+            // For GitHub Enterprise, use the enterprise API URL format
+            // GitHub Enterprise API URL format: https://github.company.com/api/v3
+            return `${url.protocol}//${hostname}/api/v3`;
+          } catch {
+            return 'https://api.github.com'; // Fallback to public GitHub if URL parsing fails
+          }
+        };
+
+        const githubApiBaseUrl = getGithubApiUrl(effectiveRepoInfo.repoUrl);
+
         for (const branch of ['main', 'master']) {
-          const apiUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
+          const apiUrl = `${githubApiBaseUrl}/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
           const headers = createGithubHeaders(currentToken);
 
           console.log(`Fetching repository structure from branch: ${branch}`);
@@ -1162,7 +1187,7 @@ IMPORTANT:
         try {
           const headers = createGithubHeaders(currentToken);
 
-          const readmeResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, {
+          const readmeResponse = await fetch(`${githubApiBaseUrl}/repos/${owner}/${repo}/readme`, {
             headers
           });
 


### PR DESCRIPTION
Some enterprise environments use self-hosted GitHub services. To support these cases, the endpoint has been updated to dynamically use the original repository URL, changing from a fixed "https://api.github.com/repos/" to a flexible domain such as "https://github.company.com/api/v3".