### PR TITLE
Fix: Force UTF-8 encoding when loading JSON configuration

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -102,7 +102,7 @@ def load_json_config(filename):
             logger.warning(f"Configuration file {config_path} does not exist")
             return {}
 
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             config = json.load(f)
             config = replace_env_placeholders(config)
             return config


### PR DESCRIPTION
## Description

This pull request resolves a `UnicodeDecodeError` that occurs when loading JSON configuration files (e.g., `lang.json`) on operating systems where the default encoding is not UTF-8, such as Japanese versions of Windows.

## The Problem

The application fails to load configuration files containing multi-byte characters, resulting in the following error:

> 2025-06-27 19:45:07,382 - ERROR - api.config - config.py:110 - Error loading configuration file lang.json: 'cp932' codec can't decode byte 0x9e in position 79: illegal multibyte sequence

This error happens because Python's `open()` function defaults to the system's local encoding (`cp932` in this case), which cannot correctly decode a file saved in UTF-8.

## The Solution

To ensure consistent behavior across all platforms, I have explicitly set the file encoding to `utf-8` within the `load_json_config` function in `api/config.py`.

This change forces the file to be read with the correct encoding, preventing the `UnicodeDecodeError` and making the configuration loading process more robust and portable.

### Changes

```diff
--- a/api/config.py
+++ b/api/config.py
@@ -102,7 +102,7 @@ def load_json_config(filename):
             logger.warning(f"Configuration file {config_path} does not exist")
             return {}
 
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             config = json.load(f)
             config = replace_env_placeholders(config)
             return config
```

## Operation check

I have confirmed that it is possible to create a Wiki for this repository.