### PR TITLE
fix: move log file to parent directory to avoid infinite logging loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ develop-eggs/
 dist/
 downloads/
 eggs/
-api/logs/
+logs/
 .eggs/
 lib/
 lib64/

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -10,7 +10,8 @@ def setup_logging(format: str = None):
     Ensures log directory exists, and configures both file and console handlers.
     """
     # Determine log directory and default file path
-    base_dir = Path(__file__).parent
+    # base_dir is now the workspace root
+    base_dir = Path(__file__).resolve().parent.parent
     log_dir = base_dir / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     default_log_file = log_dir / "application.log"

--- a/api/main.py
+++ b/api/main.py
@@ -53,5 +53,6 @@ if __name__ == "__main__":
         "api.api:app",
         host="0.0.0.0",
         port=port,
-        reload=is_development
+        reload=is_development,
+        reload_dirs=["api"] if is_development else None
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,10 @@ services:
       - NODE_ENV=production
       - SERVER_BASE_URL=http://localhost:${PORT:-8001}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - LOG_FILE_PATH=${LOG_FILE_PATH:-api/logs/application.log}
+      - LOG_FILE_PATH=${LOG_FILE_PATH:-logs/application.log}
     volumes:
       - ~/.adalflow:/root/.adalflow      # Persist repository and embedding data
-      - ./api/logs:/app/api/logs          # Persist log files across container restarts
+      - ./logs:/app/logs          # Persist log files across container restarts
     # Resource limits for docker-compose up (not Swarm mode)
     mem_limit: 6g
     mem_reservation: 2g


### PR DESCRIPTION
In the previous pull request https://github.com/AsyncFuncAI/deepwiki-open/pull/210, it didn't solve the issue, but just ignored it by using the WARNING log level. 

And according to the discussion in https://github.com/encode/uvicorn/discussions/1656 , the only solution is to change the log file's location.