### PR TITLE
fix: add IgnoreLogChangeDetectedFilter for logging to ignore changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ develop-eggs/
 dist/
 downloads/
 eggs/
-logs/
+api/logs/
 .eggs/
 lib/
 lib64/

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -10,8 +10,7 @@ def setup_logging(format: str = None):
     Ensures log directory exists, and configures both file and console handlers.
     """
     # Determine log directory and default file path
-    # base_dir is now the workspace root
-    base_dir = Path(__file__).resolve().parent.parent
+    base_dir = Path(__file__).parent
     log_dir = base_dir / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     default_log_file = log_dir / "application.log"

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 class IgnoreLogChangeDetectedFilter(logging.Filter):
     def filter(self, record: logging.LogRecord):
-        return "change detected" not in record.getMessage()
+        return "Detected file change in" not in record.getMessage()
 
 def setup_logging(format: str = None):
     """

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -2,6 +2,9 @@ import logging
 import os
 from pathlib import Path
 
+class IgnoreLogChangeDetectedFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord):
+        return "change detected" not in record.getMessage()
 
 def setup_logging(format: str = None):
     """
@@ -41,6 +44,10 @@ def setup_logging(format: str = None):
         ],
         force=True
     )
+    
+    # Ignore log file's change detection
+    for handler in logging.getLogger().handlers:
+        handler.addFilter(IgnoreLogChangeDetectedFilter())
 
     # Initial debug message to confirm configuration
     logger = logging.getLogger(__name__)

--- a/api/main.py
+++ b/api/main.py
@@ -53,6 +53,5 @@ if __name__ == "__main__":
         "api.api:app",
         host="0.0.0.0",
         port=port,
-        reload=is_development,
-        reload_dirs=["api"] if is_development else None
+        reload=is_development
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,10 @@ services:
       - NODE_ENV=production
       - SERVER_BASE_URL=http://localhost:${PORT:-8001}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - LOG_FILE_PATH=${LOG_FILE_PATH:-logs/application.log}
+      - LOG_FILE_PATH=${LOG_FILE_PATH:-api/logs/application.log}
     volumes:
       - ~/.adalflow:/root/.adalflow      # Persist repository and embedding data
-      - ./logs:/app/logs          # Persist log files across container restarts
+      - ./api/logs:/app/api/logs          # Persist log files across container restarts
     # Resource limits for docker-compose up (not Swarm mode)
     mem_limit: 6g
     mem_reservation: 2g


### PR DESCRIPTION
I am sorry for my previous PR, seems that is not the correct fix, because watcher will watch the current working directory, but we will run `python -m api.main` in the workspace root, so the watcher still detected the changes, `reload_dir` just decided which directory will be reloaded and didn't affect watchers.

This patch has correct fix and didn't change log file's location. 

I tested it and looks good to me.