### PR TITLE
fix issue with select options background on google chrome browser

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,7 +33,7 @@ html[data-theme='dark'] {
 
 [data-theme="dark"] select option, /* Fix for google chrome browser */
 .dark select option {
-  background: #1a1a1a; /* Deep charcoal */
+  background: var(--background);
 }
 
 @theme inline {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,8 +31,8 @@ html[data-theme='dark'] {
   --link-color: #b19cd9; /* Lighter purple for dark mode links */
 }
 
-[data-theme="dark"] select option, /* Fix for google chrome browser */
-.dark select option {
+/* Fix for unreadable <select> options in Chrome's dark mode */
+[data-theme="dark"] select option {
   background: var(--background);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,11 @@ html[data-theme='dark'] {
   --link-color: #b19cd9; /* Lighter purple for dark mode links */
 }
 
+[data-theme="dark"] select option, /* Fix for google chrome browser */
+.dark select option {
+  background: #1a1a1a; /* Deep charcoal */
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);


### PR DESCRIPTION
In this PR provide small styles fix for issue related to unreadable select options in google chrome browser.
When dark theme is enabled, options appear as light gray text on white background which is hard to read and inconsistent with the theme.

I attach also screenshots with select options before and after code changes.

My Google Chrome version is Version 138.0.7204.92 (Official Build) (64-bit)
My OS: Ubuntu 24.04.2 LTS

![Screenshot from 2025-07-08 08-22-11](https://github.com/user-attachments/assets/812cfc69-f33f-4265-9eb2-4672892155f7)
![Screenshot from 2025-07-08 09-18-10](https://github.com/user-attachments/assets/0b8ac70e-b000-4dc5-a9a7-4c537999c5c2)
