### PR TITLE
fix support for bitbucket and gitlab repository links

### DIFF
--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -192,11 +192,13 @@ export default function RepoWikiPage() {
   const isCustomModelParam = searchParams.get('is_custom_model') === 'true';
   const customModelParam = searchParams.get('custom_model') || '';
   const language = searchParams.get('language') || 'en';
-  let repoType;
-  if (repoUrl?.includes('bitbucket.org')) repoType = 'bitbucket';
-  else if (repoUrl?.includes('gitlab.com')) repoType = 'gitlab';
-  else if (repoUrl?.includes('github.com')) repoType = 'github';
-  else repoType = searchParams.get('type') || 'github';
+  const repoType = repoUrl?.includes('bitbucket.org')
+    ? 'bitbucket'
+    : repoUrl?.includes('gitlab.com')
+      ? 'gitlab'
+      : repoUrl?.includes('github.com')
+        ? 'github'
+        : searchParams.get('type') || 'github';
 
   // Import language context for translations
   const { messages } = useLanguage();

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -185,7 +185,6 @@ export default function RepoWikiPage() {
 
   // Extract tokens from search params
   const token = searchParams.get('token') || '';
-  const repoType = searchParams.get('type') || 'github';
   const localPath = searchParams.get('local_path') ? decodeURIComponent(searchParams.get('local_path') || '') : undefined;
   const repoUrl = searchParams.get('repo_url') ? decodeURIComponent(searchParams.get('repo_url') || '') : undefined;
   const providerParam = searchParams.get('provider') || '';
@@ -193,6 +192,11 @@ export default function RepoWikiPage() {
   const isCustomModelParam = searchParams.get('is_custom_model') === 'true';
   const customModelParam = searchParams.get('custom_model') || '';
   const language = searchParams.get('language') || 'en';
+  let repoType;
+  if (repoUrl?.includes('bitbucket.org')) repoType = 'bitbucket';
+  else if (repoUrl?.includes('gitlab.com')) repoType = 'gitlab';
+  else if (repoUrl?.includes('github.com')) repoType = 'github';
+  else repoType = searchParams.get('type') || 'github';
 
   // Import language context for translations
   const { messages } = useLanguage();


### PR DESCRIPTION
In this PR I provide fix support for bitbucket and gitlab repository links.

repoType was chosen based on GET param which is "github" by default.
This GET param is changed only when "access token" section repository type is selected, but UI suggest that it's recognized automatically.
<img width="1051" height="351" alt="Screenshot from 2025-07-12 19-06-26" src="https://github.com/user-attachments/assets/44b6c85c-22a9-4f56-a783-0cb6578bdee0" />

therefore when using suggested link for open bitbucket repository (https://bitbucket.org/atlassian/atlaskit) it end with 404 error message that comes from github related condition

Changed code to detect repository type from URL in first place.
