### PR TITLE
fix clone bitbucket with access token

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -99,8 +99,9 @@ def download_repo(repo_url: str, local_path: str, type: str = "github", access_t
                 # Format: https://oauth2:{token}@gitlab.com/owner/repo.git
                 clone_url = urlunparse((parsed.scheme, f"oauth2:{access_token}@{parsed.netloc}", parsed.path, '', '', ''))
             elif type == "bitbucket":
-                # Format: https://{token}@bitbucket.org/owner/repo.git
-                clone_url = urlunparse((parsed.scheme, f"{access_token}@{parsed.netloc}", parsed.path, '', '', ''))
+                # Format: https://x-token-auth:{token}@bitbucket.org/owner/repo.git
+                clone_url = urlunparse((parsed.scheme, f"x-token-auth:{access_token}@{parsed.netloc}", parsed.path, '', '', ''))
+
             logger.info("Using access token for authentication")
 
         # Clone the repository


### PR DESCRIPTION
In this PR I provide a fix for accessing bitbucket repository with access token.

It didn't work initially until adding x-token-auth: prefix in URL as suggested in bitbucket token generation page.
Afterwards was able to generate deepwiki for my private bitbucket repository:
<img width="1250" height="566" alt="image" src="https://github.com/user-attachments/assets/bdfd7517-abf9-4700-ac2b-93dd2ef88798" />
