### PR TITLE
fix projects route env variable

### DIFF
--- a/src/app/api/wiki/projects/route.ts
+++ b/src/app/api/wiki/projects/route.ts
@@ -31,7 +31,7 @@ function isDeleteProjectCachePayload(obj: unknown): obj is DeleteProjectCachePay
 }
 
 // Ensure this matches your Python backend configuration
-const PYTHON_BACKEND_URL = process.env.PYTHON_BACKEND_HOST || 'http://localhost:8001';
+const PYTHON_BACKEND_URL = process.env.SERVER_BASE_URL || 'http://localhost:8001';
 const PROJECTS_API_ENDPOINT = `${PYTHON_BACKEND_URL}/api/processed_projects`;
 const CACHE_API_ENDPOINT = `${PYTHON_BACKEND_URL}/api/wiki_cache`;
 


### PR DESCRIPTION
This pull request updates the way the backend server URL is configured in the `src/app/api/wiki/projects/route.ts` file. The main change is to use the `SERVER_BASE_URL` environment variable instead of `PYTHON_BACKEND_HOST` for setting the backend URL, making it more consistent with other configuration patterns.

Configuration update:

* Changed the backend URL environment variable from `PYTHON_BACKEND_HOST` to `SERVER_BASE_URL` in `src/app/api/wiki/projects/route.ts` to standardize server configuration.