### PR TITLE
Adds branch support for repository retrieval

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -55,7 +55,7 @@ def count_tokens(text: str, is_ollama_embedder: bool = None) -> int:
         # Rough approximation: 4 characters per token
         return len(text) // 4
 
-def download_repo(repo_url: str, local_path: str, type: str = "github", access_token: str = None) -> str:
+def download_repo(repo_url: str, local_path: str, type: str = "github", access_token: str = None, branch: str = None) -> str:
     """
     Downloads a Git repository (GitHub, GitLab, or Bitbucket) to a specified local path.
 
@@ -107,8 +107,12 @@ def download_repo(repo_url: str, local_path: str, type: str = "github", access_t
         # Clone the repository
         logger.info(f"Cloning repository from {repo_url} to {local_path}")
         # We use repo_url in the log to avoid exposing the token in logs
+        clone_args = ["git", "clone", "--depth=1", "--single-branch"]
+        if branch:
+            clone_args.extend(["-b", branch])
+        clone_args.extend([clone_url, local_path])
         result = subprocess.run(
-            ["git", "clone", "--depth=1", "--single-branch", clone_url, local_path],
+            clone_args,
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -413,7 +417,7 @@ def transform_documents_and_save_to_db(
     db.save_state(filepath=db_path)
     return db
 
-def get_github_file_content(repo_url: str, file_path: str, access_token: str = None) -> str:
+def get_github_file_content(repo_url: str, file_path: str, access_token: str = None, branch: str = None) -> str:
     """
     Retrieves the content of a file from a GitHub repository using the GitHub API.
     Supports both public GitHub (github.com) and GitHub Enterprise (custom domains).
@@ -455,6 +459,8 @@ def get_github_file_content(repo_url: str, file_path: str, access_token: str = N
         # Use GitHub API to get file content
         # The API endpoint for getting file content is: /repos/{owner}/{repo}/contents/{path}
         api_url = f"{api_base}/repos/{owner}/{repo}/contents/{file_path}"
+        if branch:
+            api_url += f"?ref={quote(branch, safe='')}"
 
         # Fetch file content from GitHub API
         headers = {}
@@ -490,7 +496,7 @@ def get_github_file_content(repo_url: str, file_path: str, access_token: str = N
     except Exception as e:
         raise ValueError(f"Failed to get file content: {str(e)}")
 
-def get_gitlab_file_content(repo_url: str, file_path: str, access_token: str = None) -> str:
+def get_gitlab_file_content(repo_url: str, file_path: str, access_token: str = None, branch: str = None) -> str:
     """
     Retrieves the content of a file from a GitLab repository (cloud or self-hosted).
 
@@ -525,27 +531,29 @@ def get_gitlab_file_content(repo_url: str, file_path: str, access_token: str = N
         # Encode file path
         encoded_file_path = quote(file_path, safe='')
 
-        # Try to get the default branch from the project info
-        default_branch = None
-        try:
-            project_info_url = f"{gitlab_domain}/api/v4/projects/{encoded_project_path}"
-            project_headers = {}
-            if access_token:
-                project_headers["PRIVATE-TOKEN"] = access_token
-            
-            project_response = requests.get(project_info_url, headers=project_headers)
-            if project_response.status_code == 200:
-                project_data = project_response.json()
-                default_branch = project_data.get('default_branch', 'main')
-                logger.info(f"Found default branch: {default_branch}")
-            else:
-                logger.warning(f"Could not fetch project info, using 'main' as default branch")
-                default_branch = 'main'
-        except Exception as e:
-            logger.warning(f"Error fetching project info: {e}, using 'main' as default branch")
-            default_branch = 'main'
+        # Determine branch/ref
+        ref = branch
+        if not ref:
+            # Try to get the default branch from the project info
+            try:
+                project_info_url = f"{gitlab_domain}/api/v4/projects/{encoded_project_path}"
+                project_headers = {}
+                if access_token:
+                    project_headers["PRIVATE-TOKEN"] = access_token
+                
+                project_response = requests.get(project_info_url, headers=project_headers)
+                if project_response.status_code == 200:
+                    project_data = project_response.json()
+                    ref = project_data.get('default_branch', 'main')
+                    logger.info(f"Found default branch: {ref}")
+                else:
+                    logger.warning(f"Could not fetch project info, using 'main' as default branch")
+                    ref = 'main'
+            except Exception as e:
+                logger.warning(f"Error fetching project info: {e}, using 'main' as default branch")
+                ref = 'main'
 
-        api_url = f"{gitlab_domain}/api/v4/projects/{encoded_project_path}/repository/files/{encoded_file_path}/raw?ref={default_branch}"
+        api_url = f"{gitlab_domain}/api/v4/projects/{encoded_project_path}/repository/files/{encoded_file_path}/raw?ref={quote(ref, safe='')}"
         # Fetch file content from GitLab API
         headers = {}
         if access_token:
@@ -572,7 +580,7 @@ def get_gitlab_file_content(repo_url: str, file_path: str, access_token: str = N
     except Exception as e:
         raise ValueError(f"Failed to get file content: {str(e)}")
 
-def get_bitbucket_file_content(repo_url: str, file_path: str, access_token: str = None) -> str:
+def get_bitbucket_file_content(repo_url: str, file_path: str, access_token: str = None, branch: str = None) -> str:
     """
     Retrieves the content of a file from a Bitbucket repository using the Bitbucket API.
 
@@ -596,29 +604,30 @@ def get_bitbucket_file_content(repo_url: str, file_path: str, access_token: str 
         owner = parts[-2]
         repo = parts[-1].replace(".git", "")
 
-        # Try to get the default branch from the repository info
-        default_branch = None
-        try:
-            repo_info_url = f"https://api.bitbucket.org/2.0/repositories/{owner}/{repo}"
-            repo_headers = {}
-            if access_token:
-                repo_headers["Authorization"] = f"Bearer {access_token}"
-            
-            repo_response = requests.get(repo_info_url, headers=repo_headers)
-            if repo_response.status_code == 200:
-                repo_data = repo_response.json()
-                default_branch = repo_data.get('mainbranch', {}).get('name', 'main')
-                logger.info(f"Found default branch: {default_branch}")
-            else:
-                logger.warning(f"Could not fetch repository info, using 'main' as default branch")
-                default_branch = 'main'
-        except Exception as e:
-            logger.warning(f"Error fetching repository info: {e}, using 'main' as default branch")
-            default_branch = 'main'
+        # Determine branch
+        ref = branch
+        if not ref:
+            try:
+                repo_info_url = f"https://api.bitbucket.org/2.0/repositories/{owner}/{repo}"
+                repo_headers = {}
+                if access_token:
+                    repo_headers["Authorization"] = f"Bearer {access_token}"
+                
+                repo_response = requests.get(repo_info_url, headers=repo_headers)
+                if repo_response.status_code == 200:
+                    repo_data = repo_response.json()
+                    ref = repo_data.get('mainbranch', {}).get('name', 'main')
+                    logger.info(f"Found default branch: {ref}")
+                else:
+                    logger.warning(f"Could not fetch repository info, using 'main' as default branch")
+                    ref = 'main'
+            except Exception as e:
+                logger.warning(f"Error fetching repository info: {e}, using 'main' as default branch")
+                ref = 'main'
 
         # Use Bitbucket API to get file content
         # The API endpoint for getting file content is: /2.0/repositories/{owner}/{repo}/src/{branch}/{path}
-        api_url = f"https://api.bitbucket.org/2.0/repositories/{owner}/{repo}/src/{default_branch}/{file_path}"
+        api_url = f"https://api.bitbucket.org/2.0/repositories/{owner}/{repo}/src/{quote(ref, safe='')}/{file_path}"
 
         # Fetch file content from Bitbucket API
         headers = {}
@@ -648,7 +657,7 @@ def get_bitbucket_file_content(repo_url: str, file_path: str, access_token: str 
         raise ValueError(f"Failed to get file content: {str(e)}")
 
 
-def get_file_content(repo_url: str, file_path: str, type: str = "github", access_token: str = None) -> str:
+def get_file_content(repo_url: str, file_path: str, type: str = "github", access_token: str = None, branch: str = None) -> str:
     """
     Retrieves the content of a file from a Git repository (GitHub or GitLab).
 
@@ -664,11 +673,11 @@ def get_file_content(repo_url: str, file_path: str, type: str = "github", access
         ValueError: If the file cannot be fetched or if the URL is not valid
     """
     if type == "github":
-        return get_github_file_content(repo_url, file_path, access_token)
+        return get_github_file_content(repo_url, file_path, access_token, branch)
     elif type == "gitlab":
-        return get_gitlab_file_content(repo_url, file_path, access_token)
+        return get_gitlab_file_content(repo_url, file_path, access_token, branch)
     elif type == "bitbucket":
-        return get_bitbucket_file_content(repo_url, file_path, access_token)
+        return get_bitbucket_file_content(repo_url, file_path, access_token, branch)
     else:
         raise ValueError("Unsupported repository URL. Only GitHub and GitLab are supported.")
 
@@ -684,7 +693,7 @@ class DatabaseManager:
 
     def prepare_database(self, repo_url_or_path: str, type: str = "github", access_token: str = None, is_ollama_embedder: bool = None,
                        excluded_dirs: List[str] = None, excluded_files: List[str] = None,
-                       included_dirs: List[str] = None, included_files: List[str] = None) -> List[Document]:
+                       included_dirs: List[str] = None, included_files: List[str] = None, branch: str = None) -> List[Document]:
         """
         Create a new database from the repository.
 
@@ -702,7 +711,7 @@ class DatabaseManager:
             List[Document]: List of Document objects
         """
         self.reset_database()
-        self._create_repo(repo_url_or_path, type, access_token)
+        self._create_repo(repo_url_or_path, type, access_token, branch)
         return self.prepare_db_index(is_ollama_embedder=is_ollama_embedder, excluded_dirs=excluded_dirs, excluded_files=excluded_files,
                                    included_dirs=included_dirs, included_files=included_files)
 
@@ -729,7 +738,7 @@ class DatabaseManager:
             repo_name = url_parts[-1].replace(".git", "")
         return repo_name
 
-    def _create_repo(self, repo_url_or_path: str, repo_type: str = "github", access_token: str = None) -> None:
+    def _create_repo(self, repo_url_or_path: str, repo_type: str = "github", access_token: str = None, branch: str = None) -> None:
         """
         Download and prepare all paths.
         Paths:
@@ -757,7 +766,7 @@ class DatabaseManager:
                 # Check if the repository directory already exists and is not empty
                 if not (os.path.exists(save_repo_dir) and os.listdir(save_repo_dir)):
                     # Only download if the repository doesn't exist or is empty
-                    download_repo(repo_url_or_path, save_repo_dir, repo_type, access_token)
+                    download_repo(repo_url_or_path, save_repo_dir, repo_type, access_token, branch)
                 else:
                     logger.info(f"Repository already exists at {save_repo_dir}. Using existing repository.")
             else:  # local path

--- a/api/rag.py
+++ b/api/rag.py
@@ -343,7 +343,7 @@ IMPORTANT FORMATTING RULES:
 
     def prepare_retriever(self, repo_url_or_path: str, type: str = "github", access_token: str = None,
                       excluded_dirs: List[str] = None, excluded_files: List[str] = None,
-                      included_dirs: List[str] = None, included_files: List[str] = None):
+                      included_dirs: List[str] = None, included_files: List[str] = None, branch: str = None):
         """
         Prepare the retriever for a repository.
         Will load database from local storage if available.
@@ -366,7 +366,8 @@ IMPORTANT FORMATTING RULES:
             excluded_dirs=excluded_dirs,
             excluded_files=excluded_files,
             included_dirs=included_dirs,
-            included_files=included_files
+            included_files=included_files,
+            branch=branch
         )
         logger.info(f"Loaded {len(self.transformed_docs)} documents for retrieval")
 

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -38,6 +38,7 @@ class ChatCompletionRequest(BaseModel):
     filePath: Optional[str] = Field(None, description="Optional path to a file in the repository to include in the prompt")
     token: Optional[str] = Field(None, description="Personal access token for private repositories")
     type: Optional[str] = Field("github", description="Type of repository (e.g., 'github', 'gitlab', 'bitbucket')")
+    branch: Optional[str] = Field(None, description="Git branch to use instead of the default branch")
 
     # model parameters
     provider: str = Field("google", description="Model provider (google, openai, openrouter, ollama, azure)")
@@ -95,7 +96,7 @@ async def handle_websocket_chat(websocket: WebSocket):
                 included_files = [unquote(file_pattern) for file_pattern in request.included_files.split('\n') if file_pattern.strip()]
                 logger.info(f"Using custom included files: {included_files}")
 
-            request_rag.prepare_retriever(request.repo_url, request.type, request.token, excluded_dirs, excluded_files, included_dirs, included_files)
+            request_rag.prepare_retriever(request.repo_url, request.type, request.token, excluded_dirs, excluded_files, included_dirs, included_files, branch=request.branch)
             logger.info(f"Retriever prepared for {request.repo_url}")
         except ValueError as e:
             if "No valid documents with embeddings found" in str(e):
@@ -391,7 +392,7 @@ This file contains...
         file_content = ""
         if request.filePath:
             try:
-                file_content = get_file_content(request.repo_url, request.filePath, request.type, request.token)
+                file_content = get_file_content(request.repo_url, request.filePath, request.type, request.token, request.branch)
                 logger.info(f"Successfully retrieved content for file: {request.filePath}")
             except Exception as e:
                 logger.error(f"Error retrieving file content: {str(e)}")

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -273,6 +273,12 @@ export default function RepoWikiPage() {
 
   // Default branch state
   const [defaultBranch, setDefaultBranch] = useState<string>('main');
+  const requestedBranch = searchParams.get('branch') || '';
+  useEffect(() => {
+    if (requestedBranch && requestedBranch.trim().length > 0) {
+      setDefaultBranch(requestedBranch.trim());
+    }
+  }, [requestedBranch]);
 
   // Helper function to generate proper repository file URLs
   const generateFileUrl = useCallback((filePath: string): string => {
@@ -509,6 +515,9 @@ Remember:
             content: promptContent
           }]
         };
+        if (requestedBranch) {
+          requestBody.branch = requestedBranch;
+        }
 
         // Add tokens if available
         addTokensToRequestBody(requestBody, currentToken, effectiveRepoInfo.type, selectedProviderState, selectedModelState, isCustomSelectedModelState, customSelectedModelState, language, modelExcludedDirs, modelExcludedFiles, modelIncludedDirs, modelIncludedFiles);
@@ -683,7 +692,12 @@ Remember:
         type: effectiveRepoInfo.type,
         messages: [{
           role: 'user',
-content: `Analyze this GitHub repository ${owner}/${repo} and create a wiki structure for it.
+          content: `Analyze this GitHub repository ${owner}/${repo} and create a wiki structure for it.
+      }]
+      } as Record<string, any>;
+      if (requestedBranch) {
+        (requestBody as any).branch = requestedBranch;
+      }
 
 1. The complete file tree of the project:
 <file_tree>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -247,6 +247,7 @@ export default function Home() {
 
   // State for configuration modal
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
+  const [branch, setBranch] = useState<string>('');
 
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -362,6 +363,10 @@ export default function Home() {
     if (isCustomModel && customModel) {
       params.append('custom_model', customModel);
     }
+    // Add branch parameter if provided
+    if (branch && branch.trim().length > 0) {
+      params.append('branch', branch.trim());
+    }
     // Add file filters configuration
     if (excludedDirs) {
       params.append('excluded_dirs', excludedDirs);
@@ -445,6 +450,8 @@ export default function Home() {
             isOpen={isConfigModalOpen}
             onClose={() => setIsConfigModalOpen(false)}
             repositoryInput={repositoryInput}
+            branchName={branch}
+            setBranchName={setBranch}
             selectedLanguage={selectedLanguage}
             setSelectedLanguage={setSelectedLanguage}
             supportedLanguages={supportedLanguages}

--- a/src/components/ConfigurationModal.tsx
+++ b/src/components/ConfigurationModal.tsx
@@ -11,6 +11,9 @@ interface ConfigurationModalProps {
 
   // Repository input
   repositoryInput: string;
+  // Branch name input
+  branchName: string;
+  setBranchName: (value: string) => void;
 
   // Language selection
   selectedLanguage: string;
@@ -64,6 +67,8 @@ export default function ConfigurationModal({
   isOpen,
   onClose,
   repositoryInput,
+  branchName,
+  setBranchName,
   selectedLanguage,
   setSelectedLanguage,
   supportedLanguages,
@@ -133,6 +138,21 @@ export default function ConfigurationModal({
               <div className="bg-[var(--background)]/70 p-3 rounded-md border border-[var(--border-color)] text-sm text-[var(--foreground)]">
                 {repositoryInput}
               </div>
+            </div>
+
+            {/* Branch name input */}
+            <div className="mb-4">
+              <label htmlFor="branchName" className="block text-sm font-medium text-[var(--foreground)] mb-2">
+                {t.form?.branchName || 'Branch name (optional)'}
+              </label>
+              <input
+                type="text"
+                id="branchName"
+                value={branchName}
+                onChange={(e) => setBranchName(e.target.value)}
+                className="input-japanese block w-full px-3 py-2 text-sm rounded-md bg-transparent text-[var(--foreground)] focus:outline-none focus:border-[var(--accent-primary)]"
+                placeholder={t.form?.branchPlaceholder || 'e.g., main, master, develop, feature/x'}
+              />
             </div>
 
             {/* Language selection */}

--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 interface TokenInputProps {
-  selectedPlatform: 'github' | 'gitlab' | 'bitbucket';
-  setSelectedPlatform: (value: 'github' | 'gitlab' | 'bitbucket') => void;
+  selectedPlatform: 'github' | 'gitlab' | 'bitbucket' | 'azure';
+  setSelectedPlatform: (value: 'github' | 'gitlab' | 'bitbucket' | 'azure') => void;
   accessToken: string;
   setAccessToken: (value: string) => void;
   showTokenSection?: boolean;
@@ -75,6 +75,16 @@ export default function TokenInput({
                     }`}
                 >
                   <span className="text-sm">Bitbucket</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSelectedPlatform('azure')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md border transition-all ${selectedPlatform === 'azure'
+                    ? 'bg-[var(--accent-primary)]/10 border-[var(--accent-primary)] text-[var(--accent-primary)] shadow-sm'
+                    : 'border-[var(--border-color)] text-[var(--foreground)] hover:bg-[var(--background)]'
+                    }`}
+                >
+                  <span className="text-sm">Azure DevOps</span>
                 </button>
               </div>
             </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "Repository",
+    "branchName": "Branch name (optional)",
     "configureWiki": "Configure Wiki",
     "repoPlaceholder": "owner/repo or GitHub/GitLab/Bitbucket URL",
     "wikiLanguage": "Wiki Language",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "Repositorio",
+    "branchName": "Nombre de rama (opcional)",
     "configureWiki": "Configurar Wiki",
     "repoPlaceholder": "propietario/repositorio o URL de GitHub/GitLab/Bitbucket",
     "wikiLanguage": "Idioma del Wiki",

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -30,6 +30,7 @@
     },
     "form": {
       "repository": "Dépôt",
+      "branchName": "Nom de branche (optionnel)",
       "configureWiki": "Configurer le Wiki",
       "repoPlaceholder": "propriétaire/dépôt ou URL GitHub/GitLab/Bitbucket",
       "wikiLanguage": "Langue du Wiki",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "リポジトリ",
+    "branchName": "ブランチ名（任意）",
     "configureWiki": "Wiki設定",
     "repoPlaceholder": "所有者/リポジトリまたはGitHub/GitLab/BitbucketのURL",
     "wikiLanguage": "Wiki言語",

--- a/src/messages/kr.json
+++ b/src/messages/kr.json
@@ -30,6 +30,7 @@
     },
     "form": {
       "repository": "저장소",
+      "branchName": "브랜치 이름(선택 사항)",
       "configureWiki": "위키 구성",
       "repoPlaceholder": "owner/repo 또는 GitHub/GitLab/Bitbucket URL",
       "wikiLanguage": "위키 언어",

--- a/src/messages/pt-br.json
+++ b/src/messages/pt-br.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "Repositório",
+    "branchName": "Nome da branch (opcional)",
     "configureWiki": "Configurar Wiki",
     "repoPlaceholder": "proprietário/repo ou URL do GitHub/GitLab/Bitbucket",
     "wikiLanguage": "Idioma da Wiki",

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "Репозиторий",
+    "branchName": "Имя ветки (необязательно)",
     "configureWiki": "Настроить Wiki",
     "repoPlaceholder": "owner/repo или URL GitHub/GitLab/Bitbucket",
     "wikiLanguage": "Язык Wiki",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "Repository",
+    "branchName": "Tên nhánh (tùy chọn)",
     "configureWiki": "Cấu hình Wiki",
     "repoPlaceholder": "owner/repo hoặc URL GitHub/GitLab/Bitbucket",
     "wikiLanguage": "Ngôn ngữ Wiki",

--- a/src/messages/zh-tw.json
+++ b/src/messages/zh-tw.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "儲存庫",
+    "branchName": "分支名稱（可選）",
     "configureWiki": "設定 Wiki",
     "repoPlaceholder": "擁有者/儲存庫或 GitHub/GitLab/Bitbucket URL",
     "wikiLanguage": "Wiki 語言",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -30,6 +30,7 @@
   },
   "form": {
     "repository": "仓库",
+    "branchName": "分支名称（可选）",
     "configureWiki": "配置Wiki",
     "repoPlaceholder": "所有者/仓库或GitHub/GitLab/Bitbucket URL",
     "wikiLanguage": "Wiki语言",


### PR DESCRIPTION
Enables specifying a branch when retrieving files and downloading repositories.

This enhancement allows users to fetch content from specific branches of GitHub, GitLab, and Bitbucket repositories, instead of being limited to the default branch. It modifies the `download_repo` and `get_file_content` functions to accept an optional 'branch' parameter. The UI is also updated to allow specifying a branch when configuring a repository.

This enables users to work with specific versions or features within a repository.
