### PR TITLE
Fix access to cleared exception variable in `openrouter_client.py`

### DIFF
--- a/api/openrouter_client.py
+++ b/api/openrouter_client.py
@@ -320,7 +320,8 @@ class OpenRouterClient(ModelClient):
                                     yield "Error: No response content from OpenRouter API"
 
                             return content_generator()
-                    except aiohttp.ClientError as e_client:
+                    except aiohttp.ClientError as e:
+                        e_client = e
                         log.error(f"Connection error with OpenRouter API: {str(e_client)}")
 
                         # Return a generator that yields the error message
@@ -328,7 +329,8 @@ class OpenRouterClient(ModelClient):
                             yield f"Connection error with OpenRouter API: {str(e_client)}. Please check your internet connection and that the OpenRouter API is accessible."
                         return connection_error_generator()
 
-            except RequestException as e_req:
+            except RequestException as e:
+                e_req = e
                 log.error(f"Error calling OpenRouter API asynchronously: {str(e_req)}")
 
                 # Return a generator that yields the error message
@@ -336,7 +338,8 @@ class OpenRouterClient(ModelClient):
                     yield f"Error calling OpenRouter API: {str(e_req)}"
                 return request_error_generator()
 
-            except Exception as e_unexp:
+            except Exception as e:
+                e_unexp = e
                 log.error(f"Unexpected error calling OpenRouter API asynchronously: {str(e_unexp)}")
 
                 # Return a generator that yields the error message


### PR DESCRIPTION
## Problem

https://github.com/AsyncFuncAI/deepwiki-open/blob/3444d0b5eb348143b2df5663cebfe17b440db4df/api/openrouter_client.py#L339-L345

The exception variable `e_unexp` is referenced after the `except` block ends, causing `NameError` being raised inside the `unexpected_error_generator` function

There are also some other `except` statements in the `openrouter_client.py` that have the same issue

https://github.com/AsyncFuncAI/deepwiki-open/blob/3444d0b5eb348143b2df5663cebfe17b440db4df/api/openrouter_client.py#L323-L337

## Impact

It's the cause of error logs like this

```
Error with OpenRouter API: cannot access free variable 'e_unexp' where it is not associated with a value in enclosing scope
```

It also hide the real exception message from the `e_unexp` (and also `e_req` and `e_client`)

## References

FYI: https://docs.python.org/3.13/reference/compound_stmts.html#except-clause

> When an exception has been assigned using as target, it is cleared at the end of the except clause. This is as if
>
> ```python
> except E as N:
>     foo
> ```
>
> was translated to
>
> ```python
> except E as N:
>     try:
>         foo
>     finally:
>         del N
> ```
>
> This means the exception must be assigned to a different name to be able to refer to it after the except clause. Exceptions are cleared because with the traceback attached to them, they form a reference cycle with the stack frame, keeping all locals in that frame alive until the next garbage collection occurs.