### PR TITLE
Make Dockerfile-ollama-local detect arch

### DIFF
--- a/Dockerfile-ollama-local
+++ b/Dockerfile-ollama-local
@@ -24,17 +24,13 @@ FROM python:3.11-slim AS ollama_base
 RUN apt-get update && apt-get install -y \
     curl
 # Detect architecture and download appropriate Ollama version
-# ARG TARGETARCH can be set at build time with --build-arg TARGETARCH=arm64 or TARGETARCH=amd64
-ARG TARGETARCH=arm64
-RUN OLLAMA_ARCH="" && \
-    if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Building for ARM64 architecture." && \
-        OLLAMA_ARCH="arm64"; \
-    elif [ "$TARGETARCH" = "amd64" ]; then \
-        echo "Building for AMD64 architecture." && \
-        OLLAMA_ARCH="amd64"; \
+RUN OLLAMA_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
+    if [ "$OLLAMA_ARCH" = "arm64" ]; then \
+        echo "Building for ARM64 architecture."; \
+    elif [ "$OLLAMA_ARCH" = "amd64" ]; then \
+        echo "Building for AMD64 architecture."; \
     else \
-        echo "Error: Unsupported architecture '$TARGETARCH'. Supported architectures are 'arm64' and 'amd64'." >&2 && \
+        echo "Error: Unsupported architecture '$OLLAMA_ARCH'. Supported architectures are 'arm64' and 'amd64'." >&2 && \
         exit 1; \
     fi && \
     curl -L "https://ollama.com/download/ollama-linux-${OLLAMA_ARCH}.tgz" -o ollama.tgz && \


### PR DESCRIPTION
Currently there is an `ARG TARGETARCH` that defaults to 'arm64', so the build fails on 'amd64'. 

The documentation in **Ollama-instruction.md** doesn't mention this in [Step 4](https://github.com/AsyncFuncAI/deepwiki-open/blob/main/Ollama-instruction.md#alternative-using-dockerfile). 
It only provides this: `docker build -f Dockerfile-ollama-local -t deepwiki:ollama-local .` without mentioning the actually required `--build-arg TARGETARCH=<arch>`:

This PR aims to fix this and actually detect the build arch.