### PR TITLE
Remove version declaration from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   deepwiki:
     build:


### PR DESCRIPTION
### Summary
This pull request removes the `version` declaration from the `docker-compose.yml` file.

### Motivation
Recent versions of Docker Compose (v1.27.0 and later) have deprecated the explicit `version` key in `docker-compose.yml` files. The Compose specification encourages omitting the `version` field, as the tool now auto-detects and supports all features based on the Compose file format used. Removing the version declaration helps prevent warnings and improves compatibility with modern Docker Compose setups.

### Changes
- Deleted the `version` key from the top of `docker-compose.yml`.

### Impact
- Ensures better compatibility with current and future Docker Compose versions.
- Eliminates deprecation warnings related to the version field.

### References
- [Compose file version removal announcement](https://docs.docker.com/compose/compose-file/compose-versioning/#version-3)
- [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md)
