### PR TITLE
Fix the problem that gitlab is incompatible with the .git suffix

### DIFF
--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -1309,7 +1309,7 @@ IMPORTANT:
       }
       else if (effectiveRepoInfo.type === 'gitlab') {
         // GitLab API approach
-        const projectPath = extractUrlPath(effectiveRepoInfo.repoUrl ?? '') ?? `${owner}/${repo}`;
+        const projectPath = extractUrlPath(effectiveRepoInfo.repoUrl ?? '')?.replace(/\.git$/, '') || `${owner}/${repo}`;
         const projectDomain = extractUrlDomain(effectiveRepoInfo.repoUrl ?? "https://gitlab.com");
         const encodedProjectPath = encodeURIComponent(projectPath);
 


### PR DESCRIPTION
In the current version, if the URL passed is a gitlab URL and contains the .git suffix at the end, the front-end will not remove the suffix when obtaining the repository structure through the API, resulting in a 404 error. This commit has fixed this problem with minimal impact.
