### PR TITLE
Fixed the issue that logs cannot be recorded in multi-threaded mode

### DIFF
--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from logging.handlers import RotatingFileHandler
+from concurrent_log_handler import ConcurrentRotatingFileHandler as RotatingFileHandler
 
 
 class IgnoreLogChangeDetectedFilter(logging.Filter):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -17,4 +17,5 @@ boto3>=1.34.0
 websockets>=11.0.3
 azure-identity>=1.12.0
 azure-core>=1.24.0
+concurrent-log-handler>=0.9.20
 


### PR DESCRIPTION
## [current performance]
When setting up multiple workers in main.py to enable the server to support multi-threading, most of the current project functions can run normally, but logs will not be recorded, and the console prompts that the corresponding log file is occupied

## [solution]
Update the native single-threaded library to a library that supports multi-threaded logging, so that it supports concurrent logging without affecting any original functions.