### PR TITLE
fix the websocket connection error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY public/ ./public/
 # Increase Node.js memory limit for build and disable telemetry
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 ENV NEXT_TELEMETRY_DISABLED=1
+# `next build` inject `SERVER_BASE_URL` into bundle.js for client, once code is builded, bundle can't be modify by .env or ENV parameters.
+ENV SERVER_BASE_URL="http://localhost:${PORT:-8001}"
 RUN NODE_ENV=production npm run build
 
 FROM python:3.11-slim AS py_deps

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,10 @@ const TARGET_SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'http://localhost:
 const nextConfig: NextConfig = {
   /* config options here */
   output: 'standalone',
+  /* expose SERVER_BASE_URL to bundle */
+  env: {
+    SERVER_BASE_URL: TARGET_SERVER_BASE_URL,
+  },
   // Optimize build for Docker
   experimental: {
     optimizePackageImports: ['@mermaid-js/mermaid', 'react-syntax-highlighter'],


### PR DESCRIPTION
#132 

Next.js doesn't expose parameters into bundle.js default.

By adding the NEXT_PUBLIC_ prefix to an environment variable, it will be exposed to the browser. 
Or adding the parameter in the `next.config.js`.


[next.config.js environment-variables](https://www.nextjs.cn/docs/api-reference/next.config.js/environment-variables)