### PR TITLE
fix directory parsing in data_pipeline

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -249,7 +249,7 @@ def read_all_documents(path: str, embedder_type: str = None, is_ollama_embedder:
             # Check if file is in an included directory
             if included_dirs:
                 for included in included_dirs:
-                    clean_included = included.split("./")[1].rstrip("/")
+                    clean_included = included.removeprefix("./").removesuffix("/")
                     if clean_included in file_path_parts:
                         is_included = True
                         break
@@ -278,7 +278,7 @@ def read_all_documents(path: str, embedder_type: str = None, is_ollama_embedder:
 
             # Check if file is in an excluded directory
             for excluded in excluded_dirs:
-                clean_excluded = excluded.split("./")[1].rstrip("/")
+                clean_excluded = excluded.removeprefix("./").removesuffix("/")
                 if clean_excluded in file_path_parts:
                     is_excluded = True
                     break

--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -249,7 +249,7 @@ def read_all_documents(path: str, embedder_type: str = None, is_ollama_embedder:
             # Check if file is in an included directory
             if included_dirs:
                 for included in included_dirs:
-                    clean_included = included.strip("./").rstrip("/")
+                    clean_included = included.split("./")[1].rstrip("/")
                     if clean_included in file_path_parts:
                         is_included = True
                         break

--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -278,7 +278,7 @@ def read_all_documents(path: str, embedder_type: str = None, is_ollama_embedder:
 
             # Check if file is in an excluded directory
             for excluded in excluded_dirs:
-                clean_excluded = excluded.strip("./").rstrip("/")
+                clean_excluded = excluded.split("./")[1].rstrip("/")
                 if clean_excluded in file_path_parts:
                     is_excluded = True
                     break


### PR DESCRIPTION
In data_pipeline function `should_process_file` directory names in `included_dirs` and `excluded_dirs` uses `.strip(“./“)`. The `strip` function in python treats “./“ as `[“.”, “/“]` and removes each occurrence of either character from the start or end of the string until neither are found.

This means that a string such as "./.git/" will become “git” when `.strip(“./“)` is applied. This leads to no documents being processed from a directory if “git” is present anywhere in the file path. Some people like me use “~/git/<project>” to store their git projects, which means all my documents were being excluded although they aren’t in the “.git” directory.

I changed the parsing to use `.removeprefix("./").removesuffix("/")` which means any folder of the structure “./.<folder name>/“ will become “.<folder name>”.