### PR TITLE
fix: URL-encode access tokens to handle special characters

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -102,17 +102,19 @@ def download_repo(repo_url: str, local_path: str, repo_type: str = None, access_
         clone_url = repo_url
         if access_token:
             parsed = urlparse(repo_url)
+            # URL-encode the token to handle special characters
+            encoded_token = quote(access_token, safe='')
             # Determine the repository type and format the URL accordingly
             if repo_type == "github":
                 # Format: https://{token}@{domain}/owner/repo.git
                 # Works for both github.com and enterprise GitHub domains
-                clone_url = urlunparse((parsed.scheme, f"{access_token}@{parsed.netloc}", parsed.path, '', '', ''))
+                clone_url = urlunparse((parsed.scheme, f"{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
             elif repo_type == "gitlab":
                 # Format: https://oauth2:{token}@gitlab.com/owner/repo.git
-                clone_url = urlunparse((parsed.scheme, f"oauth2:{access_token}@{parsed.netloc}", parsed.path, '', '', ''))
+                clone_url = urlunparse((parsed.scheme, f"oauth2:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
             elif repo_type == "bitbucket":
                 # Format: https://x-token-auth:{token}@bitbucket.org/owner/repo.git
-                clone_url = urlunparse((parsed.scheme, f"x-token-auth:{access_token}@{parsed.netloc}", parsed.path, '', '', ''))
+                clone_url = urlunparse((parsed.scheme, f"x-token-auth:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
 
             logger.info("Using access token for authentication")
 
@@ -131,9 +133,13 @@ def download_repo(repo_url: str, local_path: str, repo_type: str = None, access_
 
     except subprocess.CalledProcessError as e:
         error_msg = e.stderr.decode('utf-8')
-        # Sanitize error message to remove any tokens
-        if access_token and access_token in error_msg:
+        # Sanitize error message to remove any tokens (both raw and URL-encoded)
+        if access_token:
+            # Remove raw token
             error_msg = error_msg.replace(access_token, "***TOKEN***")
+            # Also remove URL-encoded token to prevent leaking encoded version
+            encoded_token = quote(access_token, safe='')
+            error_msg = error_msg.replace(encoded_token, "***TOKEN***")
         raise ValueError(f"Error during cloning: {error_msg}")
     except Exception as e:
         raise ValueError(f"An unexpected error occurred: {str(e)}")
@@ -780,6 +786,9 @@ class DatabaseManager:
         logger.info(f"Preparing repo storage for {repo_url_or_path}...")
 
         try:
+            # Strip whitespace to handle URLs with leading/trailing spaces
+            repo_url_or_path = repo_url_or_path.strip()
+            
             root_path = get_adalflow_default_root_path()
 
             os.makedirs(root_path, exist_ok=True)


### PR DESCRIPTION
Fixes authentication failures when using access tokens containing special characters (e.g., underscores, hyphens) for private repositories.

## Problem:

- Access tokens with special characters were not being URL-encoded before being embedded in git clone URLs
- This caused 'URL rejected: Malformed input to a URL function' errors
- Affected GitHub, GitLab, and Bitbucket private repository access

## Solution:

- URL-encode tokens using `quote(access_token, safe="")` before embedding in authentication URLs for all supported platforms (GitHub, GitLab, Bitbucket)
- Also strips leading/trailing whitespace from repository URLs to prevent parsing issues

## Tested with:

- GitLab tokens containing underscores and hyphens
- Custom GitLab instances (non-gitlab.com domains)
- Private repositories on GitHub, GitLab, and Bitbucket