### PR TITLE
fix(api): use explicit file paths instead of glob for dev watcher

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -35,9 +35,8 @@ if is_development:
             item_path = os.path.join(current_dir, item)
             if os.path.isdir(item_path) and item != "logs":
                 api_subdirs.append(item_path)
-        
-        # Also add Python files in the api root directory
-        api_subdirs.append(current_dir + "/*.py")
+            elif os.path.isfile(item_path) and item.endswith(".py"):
+                api_subdirs.append(item_path)
         
         return original_watch(*api_subdirs, **kwargs)
     watchfiles.watch = patched_watch


### PR DESCRIPTION
 Update the development file watcher logic in `api/main.py` to explicitly add individual Python files found in the root directory. Previously, a glob pattern string (`/*.py`) was appended to the watch list, which is now replaced by iterating through the directory and adding specific file paths to ensure accurate file monitoring.