### PR TITLE
docs: fix api install instructions and project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ deepwiki/
 │   ├── api.py            # FastAPI implementation
 │   ├── rag.py            # Retrieval Augmented Generation
 │   ├── data_pipeline.py  # Data processing utilities
-│   └── requirements.txt  # Python dependencies
+│   ├── pyproject.toml     # Python dependencies (Poetry)
+│   └── poetry.lock        # Locked Python dependency versions
 │
 ├── src/                  # Frontend Next.js app
 │   ├── app/              # Next.js app directory

--- a/api/README.md
+++ b/api/README.md
@@ -16,7 +16,7 @@ This is the backend API for DeepWiki, providing smart code analysis and AI-power
 
 ```bash
 # From the project root
-python -m pip install poetry==2.0.1 && poetry install
+python -m pip install poetry==2.0.1 && poetry install -C api
 ```
 
 ### Step 2: Set Up Environment Variables


### PR DESCRIPTION
## Summary
This PR fixes two documentation inconsistencies around backend dependency installation and the repository structure overview.

## Changes
- **Root [README.md](https://github.com/AsyncFuncAI/deepwiki-open/blob/8f610c0/README.md?plain=1#L175)**
  - Updated the project structure section to reflect that the backend (`api/`) uses **Poetry** ([pyproject.toml](https://github.com/AsyncFuncAI/deepwiki-open/blob/8f610c0/api/pyproject.toml) + [poetry.lock](https://github.com/AsyncFuncAI/deepwiki-open/blob/8f610c0/api/poetry.lock)) instead of a `requirements.txt`.
- **API README ([api/README.md](https://github.com/AsyncFuncAI/deepwiki-open/blob/8f610c0/api/README.md?plain=1#L19))**
  - Fixed the install command when running from the repository root:
    - From `poetry install`
    - To `poetry install -C api`

## Why
- Running `poetry install` from the repository root fails because there is no `pyproject.toml` in the root directory. The backend Poetry project lives under `api/`.
- The structure section previously referenced `api/requirements.txt`, which is not the actual dependency source of truth for the backend.

## How to verify
- From the repo root:
  - `python -m pip install poetry==2.0.1 && poetry install -C api`
- Confirm that the [README.md](https://github.com/AsyncFuncAI/deepwiki-open/blob/8f610c0/README.md) project structure correctly lists [api/pyproject.toml](https://github.com/AsyncFuncAI/deepwiki-open/blob/8f610c0/api/pyproject.toml) and [api/poetry.lock](https://github.com/AsyncFuncAI/deepwiki-open/blob/8f610c0/api/poetry.lock).

## Scope
Documentation-only change. No runtime / code changes.