### PR TITLE
fix: add initialize_kwargs for embedder API authentication

### DIFF
--- a/api/config/embedder.json
+++ b/api/config/embedder.json
@@ -1,10 +1,13 @@
 {
   "embedder": {
     "client_class": "OpenAIClient",
+    "initialize_kwargs": {
+      "api_key": "${OPENAI_API_KEY}",
+      "base_url": "${OPENAI_BASE_URL}"
+    },
     "batch_size": 500,
     "model_kwargs": {
       "model": "text-embedding-3-small",
-      "dimensions": 256,
       "encoding_format": "float"
     }
   },
@@ -16,6 +19,9 @@
   },
   "embedder_google": {
     "client_class": "GoogleEmbedderClient",
+    "initialize_kwargs": {
+      "api_key": "${GOOGLE_API_KEY}"
+    },
     "batch_size": 100,
     "model_kwargs": {
       "model": "text-embedding-004",


### PR DESCRIPTION
## Problem

This PR addresses the "No valid embeddings found in any documents" error reported in issue #252 and related issues (#198, #266, #334).

The root cause is that the embedder configuration in `api/config/embedder.json` was missing the `initialize_kwargs` section, which is required to pass API credentials to the embedder client. Without this, the embedder cannot authenticate with OpenAI-compatible APIs or Google APIs, resulting in failed embedding requests.

Additionally, the `dimensions` field in `model_kwargs` causes errors with embedding models that do not support matryoshka representation (e.g., bge, Qwen).

## Changes

1. **Added `initialize_kwargs` to the OpenAI embedder configuration**
   - Includes `api_key` and `base_url` placeholders that are substituted from environment variables
   - Enables authentication with OpenAI-compatible embedding APIs

2. **Removed the `dimensions` field from `model_kwargs`**
   - Prevents errors with models that do not support matryoshka representation

3. **Added `initialize_kwargs` to the Google embedder configuration**
   - Includes `api_key` placeholder for Google API authentication

## Configuration

Users need to set the following environment variables:

- `OPENAI_API_KEY` - API key for OpenAI-compatible embedding models
- `OPENAI_BASE_URL` - Base URL for OpenAI-compatible API endpoints
- `GOOGLE_API_KEY` - (Optional) API key for Google embedding models

The `${ENV_VAR}` placeholders in the configuration are automatically replaced with environment variable values at runtime.

## Related Issues

- Fixes #252
- Related to #198, #266, #334
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/asyncfuncai/deepwiki-open/pull/457">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
