### PR TITLE
Fix: correct Ollama installation using tar.zst format

### DIFF
--- a/Dockerfile-ollama-local
+++ b/Dockerfile-ollama-local
@@ -27,7 +27,8 @@ RUN python -m pip install poetry==2.0.1 --no-cache-dir && \
 FROM python:3.11-slim AS ollama_base
 RUN apt-get update && apt-get install -y \
     curl \
-    zstd
+    zstd && \
+    rm -rf /var/lib/apt/lists/*
 
 # Detect architecture and download appropriate Ollama version
 # ARG TARGETARCH can be set at build time with --build-arg TARGETARCH=arm64 or TARGETARCH=amd64

--- a/Dockerfile-ollama-local
+++ b/Dockerfile-ollama-local
@@ -26,7 +26,9 @@ RUN python -m pip install poetry==2.0.1 --no-cache-dir && \
 
 FROM python:3.11-slim AS ollama_base
 RUN apt-get update && apt-get install -y \
-    curl
+    curl \
+    zstd
+
 # Detect architecture and download appropriate Ollama version
 # ARG TARGETARCH can be set at build time with --build-arg TARGETARCH=arm64 or TARGETARCH=amd64
 ARG TARGETARCH=arm64
@@ -41,9 +43,9 @@ RUN OLLAMA_ARCH="" && \
         echo "Error: Unsupported architecture '$TARGETARCH'. Supported architectures are 'arm64' and 'amd64'." >&2 && \
         exit 1; \
     fi && \
-    curl -L "https://ollama.com/download/ollama-linux-${OLLAMA_ARCH}.tgz" -o ollama.tgz && \
-    tar -C /usr -xzf ollama.tgz && \
-    rm ollama.tgz
+    curl -L "https://ollama.com/download/ollama-linux-${OLLAMA_ARCH}.tar.zst" -o ollama.tar.zst && \
+    tar --zstd -xf ollama.tar.zst -C /usr && \
+    rm ollama.tar.zst
 
 RUN ollama serve > /dev/null 2>&1 & \
     sleep 20 && \


### PR DESCRIPTION
This MR will change the following regarding the Ollama Dockerfile:

- Add zstd package to the apt-get install command
- Change URL from .tgz to .tar.zst (the correct Ollama download format)
- Update tar command to use --zstd flag instead of -z (gzip)
- Add cleanup of apt cache with rm -rf /var/lib/apt/lists/* to reduce image size