### PR TITLE
Fix reasoning model support (gpt-5.2-pro) by making temperature conditional

### DIFF
--- a/api/config/generator.json
+++ b/api/config/generator.json
@@ -53,6 +53,10 @@
         "gpt-5-mini": {
           "temperature": 1.0
         },
+        "gpt-5.2": {
+          "temperature": 1.0
+        },
+        "gpt-5.2-pro": {},
         "gpt-4o": {
           "temperature": 0.7,
           "top_p": 0.8

--- a/api/config/generator.json
+++ b/api/config/generator.json
@@ -56,7 +56,9 @@
         "gpt-5.2": {
           "temperature": 1.0
         },
-        "gpt-5.2-pro": {},
+        "gpt-5.2-pro": {
+          "use_responses_api": true
+        },
         "gpt-4o": {
           "temperature": 0.7,
           "top_p": 0.8

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -384,9 +384,11 @@ async def chat_completions_stream(request: ChatCompletionRequest):
             model_kwargs = {
                 "model": request.model,
                 "stream": True,
-                "temperature": model_config["temperature"]
             }
-            # Only add top_p if it exists in the model config
+            # Only add temperature/top_p if they exist in the model config
+            # (reasoning models like gpt-5.2-pro do not support these parameters)
+            if "temperature" in model_config:
+                model_kwargs["temperature"] = model_config["temperature"]
             if "top_p" in model_config:
                 model_kwargs["top_p"] = model_config["top_p"]
 

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -379,24 +379,27 @@ async def chat_completions_stream(request: ChatCompletionRequest):
                 logger.warning("OPENAI_API_KEY not configured, but continuing with request")
                 # We'll let the OpenAIClient handle this and return an error message
 
-            # Initialize Openai client
-            model = OpenAIClient()
-            model_kwargs = {
-                "model": request.model,
-                "stream": True,
-            }
-            # Only add temperature/top_p if they exist in the model config
-            # (reasoning models like gpt-5.2-pro do not support these parameters)
-            if "temperature" in model_config:
-                model_kwargs["temperature"] = model_config["temperature"]
-            if "top_p" in model_config:
-                model_kwargs["top_p"] = model_config["top_p"]
+            use_responses_api = model_config.get("use_responses_api", False)
 
-            api_kwargs = model.convert_inputs_to_api_kwargs(
-                input=prompt,
-                model_kwargs=model_kwargs,
-                model_type=ModelType.LLM
-            )
+            if not use_responses_api:
+                # Initialize Openai client (Chat Completions API)
+                model = OpenAIClient()
+                model_kwargs = {
+                    "model": request.model,
+                    "stream": True,
+                }
+                # Only add temperature/top_p if they exist in the model config
+                # (reasoning models like gpt-5.2-pro do not support these parameters)
+                if "temperature" in model_config:
+                    model_kwargs["temperature"] = model_config["temperature"]
+                if "top_p" in model_config:
+                    model_kwargs["top_p"] = model_config["top_p"]
+
+                api_kwargs = model.convert_inputs_to_api_kwargs(
+                    input=prompt,
+                    model_kwargs=model_kwargs,
+                    model_type=ModelType.LLM
+                )
         elif request.provider == "bedrock":
             logger.info(f"Using AWS Bedrock with model: {request.model}")
 
@@ -487,18 +490,31 @@ async def chat_completions_stream(request: ChatCompletionRequest):
                         yield f"\nError with OpenRouter API: {str(e_openrouter)}\n\nPlease check that you have set the OPENROUTER_API_KEY environment variable with a valid API key."
                 elif request.provider == "openai":
                     try:
-                        # Get the response and handle it properly using the previously created api_kwargs
-                        logger.info("Making Openai API call")
-                        response = await model.acall(api_kwargs=api_kwargs, model_type=ModelType.LLM)
-                        # Handle streaming response from Openai
-                        async for chunk in response:
-                           choices = getattr(chunk, "choices", [])
-                           if len(choices) > 0:
-                               delta = getattr(choices[0], "delta", None)
-                               if delta is not None:
-                                    text = getattr(delta, "content", None)
-                                    if text is not None:
-                                        yield text
+                        if use_responses_api:
+                            logger.info("Making OpenAI Responses API call")
+                            from openai import OpenAI as OpenAISyncClient
+                            responses_client = OpenAISyncClient()
+                            stream = responses_client.responses.create(
+                                model=request.model,
+                                input=prompt,
+                                stream=True,
+                            )
+                            for event in stream:
+                                if event.type == "response.output_text.delta":
+                                    yield event.delta
+                        else:
+                            # Get the response and handle it properly using the previously created api_kwargs
+                            logger.info("Making Openai API call")
+                            response = await model.acall(api_kwargs=api_kwargs, model_type=ModelType.LLM)
+                            # Handle streaming response from Openai
+                            async for chunk in response:
+                               choices = getattr(chunk, "choices", [])
+                               if len(choices) > 0:
+                                   delta = getattr(choices[0], "delta", None)
+                                   if delta is not None:
+                                        text = getattr(delta, "content", None)
+                                        if text is not None:
+                                            yield text
                     except Exception as e_openai:
                         logger.error(f"Error with Openai API: {str(e_openai)}")
                         yield f"\nError with Openai API: {str(e_openai)}\n\nPlease check that you have set the OPENAI_API_KEY environment variable with a valid API key."
@@ -619,21 +635,34 @@ async def chat_completions_stream(request: ChatCompletionRequest):
                                 yield f"\nError with OpenRouter API fallback: {str(e_fallback)}\n\nPlease check that you have set the OPENROUTER_API_KEY environment variable with a valid API key."
                         elif request.provider == "openai":
                             try:
-                                # Create new api_kwargs with the simplified prompt
-                                fallback_api_kwargs = model.convert_inputs_to_api_kwargs(
-                                    input=simplified_prompt,
-                                    model_kwargs=model_kwargs,
-                                    model_type=ModelType.LLM
-                                )
+                                if use_responses_api:
+                                    logger.info("Making fallback OpenAI Responses API call")
+                                    from openai import OpenAI as OpenAISyncClient
+                                    responses_client = OpenAISyncClient()
+                                    stream = responses_client.responses.create(
+                                        model=request.model,
+                                        input=simplified_prompt,
+                                        stream=True,
+                                    )
+                                    for event in stream:
+                                        if event.type == "response.output_text.delta":
+                                            yield event.delta
+                                else:
+                                    # Create new api_kwargs with the simplified prompt
+                                    fallback_api_kwargs = model.convert_inputs_to_api_kwargs(
+                                        input=simplified_prompt,
+                                        model_kwargs=model_kwargs,
+                                        model_type=ModelType.LLM
+                                    )
 
-                                # Get the response using the simplified prompt
-                                logger.info("Making fallback Openai API call")
-                                fallback_response = await model.acall(api_kwargs=fallback_api_kwargs, model_type=ModelType.LLM)
+                                    # Get the response using the simplified prompt
+                                    logger.info("Making fallback Openai API call")
+                                    fallback_response = await model.acall(api_kwargs=fallback_api_kwargs, model_type=ModelType.LLM)
 
-                                # Handle streaming fallback_response from Openai
-                                async for chunk in fallback_response:
-                                    text = chunk if isinstance(chunk, str) else getattr(chunk, 'text', str(chunk))
-                                    yield text
+                                    # Handle streaming fallback_response from Openai
+                                    async for chunk in fallback_response:
+                                        text = chunk if isinstance(chunk, str) else getattr(chunk, 'text', str(chunk))
+                                        yield text
                             except Exception as e_fallback:
                                 logger.error(f"Error with Openai API fallback: {str(e_fallback)}")
                                 yield f"\nError with Openai API fallback: {str(e_fallback)}\n\nPlease check that you have set the OPENAI_API_KEY environment variable with a valid API key."

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -489,24 +489,27 @@ This file contains...
                 logger.warning("OPENAI_API_KEY not configured, but continuing with request")
                 # We'll let the OpenAIClient handle this and return an error message
 
-            # Initialize Openai client
-            model = OpenAIClient()
-            model_kwargs = {
-                "model": request.model,
-                "stream": True,
-            }
-            # Only add temperature/top_p if they exist in the model config
-            # (reasoning models like gpt-5.2-pro do not support these parameters)
-            if "temperature" in model_config:
-                model_kwargs["temperature"] = model_config["temperature"]
-            if "top_p" in model_config:
-                model_kwargs["top_p"] = model_config["top_p"]
+            use_responses_api = model_config.get("use_responses_api", False)
 
-            api_kwargs = model.convert_inputs_to_api_kwargs(
-                input=prompt,
-                model_kwargs=model_kwargs,
-                model_type=ModelType.LLM
-            )
+            if not use_responses_api:
+                # Initialize Openai client (Chat Completions API)
+                model = OpenAIClient()
+                model_kwargs = {
+                    "model": request.model,
+                    "stream": True,
+                }
+                # Only add temperature/top_p if they exist in the model config
+                # (reasoning models like gpt-5.2-pro do not support these parameters)
+                if "temperature" in model_config:
+                    model_kwargs["temperature"] = model_config["temperature"]
+                if "top_p" in model_config:
+                    model_kwargs["top_p"] = model_config["top_p"]
+
+                api_kwargs = model.convert_inputs_to_api_kwargs(
+                    input=prompt,
+                    model_kwargs=model_kwargs,
+                    model_type=ModelType.LLM
+                )
         elif request.provider == "bedrock":
             logger.info(f"Using AWS Bedrock with model: {request.model}")
 
@@ -622,18 +625,33 @@ This file contains...
                     await websocket.close()
             elif request.provider == "openai":
                 try:
-                    # Get the response and handle it properly using the previously created api_kwargs
-                    logger.info("Making Openai API call")
-                    response = await model.acall(api_kwargs=api_kwargs, model_type=ModelType.LLM)
-                    # Handle streaming response from Openai
-                    async for chunk in response:
-                        choices = getattr(chunk, "choices", [])
-                        if len(choices) > 0:
-                            delta = getattr(choices[0], "delta", None)
-                            if delta is not None:
-                                text = getattr(delta, "content", None)
-                                if text is not None:
-                                    await websocket.send_text(text)
+                    if use_responses_api:
+                        # Use the Responses API for models that don't support Chat Completions
+                        # (e.g. gpt-5.2-pro)
+                        logger.info("Making OpenAI Responses API call")
+                        from openai import OpenAI as OpenAISyncClient
+                        responses_client = OpenAISyncClient()
+                        stream = responses_client.responses.create(
+                            model=request.model,
+                            input=prompt,
+                            stream=True,
+                        )
+                        for event in stream:
+                            if event.type == "response.output_text.delta":
+                                await websocket.send_text(event.delta)
+                    else:
+                        # Get the response and handle it properly using the previously created api_kwargs
+                        logger.info("Making Openai API call")
+                        response = await model.acall(api_kwargs=api_kwargs, model_type=ModelType.LLM)
+                        # Handle streaming response from Openai
+                        async for chunk in response:
+                            choices = getattr(chunk, "choices", [])
+                            if len(choices) > 0:
+                                delta = getattr(choices[0], "delta", None)
+                                if delta is not None:
+                                    text = getattr(delta, "content", None)
+                                    if text is not None:
+                                        await websocket.send_text(text)
                     # Explicitly close the WebSocket connection after the response is complete
                     await websocket.close()
                 except Exception as e_openai:
@@ -776,21 +794,34 @@ This file contains...
                             await websocket.send_text(error_msg)
                     elif request.provider == "openai":
                         try:
-                            # Create new api_kwargs with the simplified prompt
-                            fallback_api_kwargs = model.convert_inputs_to_api_kwargs(
-                                input=simplified_prompt,
-                                model_kwargs=model_kwargs,
-                                model_type=ModelType.LLM
-                            )
+                            if use_responses_api:
+                                logger.info("Making fallback OpenAI Responses API call")
+                                from openai import OpenAI as OpenAISyncClient
+                                responses_client = OpenAISyncClient()
+                                stream = responses_client.responses.create(
+                                    model=request.model,
+                                    input=simplified_prompt,
+                                    stream=True,
+                                )
+                                for event in stream:
+                                    if event.type == "response.output_text.delta":
+                                        await websocket.send_text(event.delta)
+                            else:
+                                # Create new api_kwargs with the simplified prompt
+                                fallback_api_kwargs = model.convert_inputs_to_api_kwargs(
+                                    input=simplified_prompt,
+                                    model_kwargs=model_kwargs,
+                                    model_type=ModelType.LLM
+                                )
 
-                            # Get the response using the simplified prompt
-                            logger.info("Making fallback Openai API call")
-                            fallback_response = await model.acall(api_kwargs=fallback_api_kwargs, model_type=ModelType.LLM)
+                                # Get the response using the simplified prompt
+                                logger.info("Making fallback Openai API call")
+                                fallback_response = await model.acall(api_kwargs=fallback_api_kwargs, model_type=ModelType.LLM)
 
-                            # Handle streaming fallback_response from Openai
-                            async for chunk in fallback_response:
-                                text = chunk if isinstance(chunk, str) else getattr(chunk, 'text', str(chunk))
-                                await websocket.send_text(text)
+                                # Handle streaming fallback_response from Openai
+                                async for chunk in fallback_response:
+                                    text = chunk if isinstance(chunk, str) else getattr(chunk, 'text', str(chunk))
+                                    await websocket.send_text(text)
                         except Exception as e_fallback:
                             logger.error(f"Error with Openai API fallback: {str(e_fallback)}")
                             error_msg = f"\nError with Openai API fallback: {str(e_fallback)}\n\nPlease check that you have set the OPENAI_API_KEY environment variable with a valid API key."

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -494,9 +494,11 @@ This file contains...
             model_kwargs = {
                 "model": request.model,
                 "stream": True,
-                "temperature": model_config["temperature"]
             }
-            # Only add top_p if it exists in the model config
+            # Only add temperature/top_p if they exist in the model config
+            # (reasoning models like gpt-5.2-pro do not support these parameters)
+            if "temperature" in model_config:
+                model_kwargs["temperature"] = model_config["temperature"]
             if "top_p" in model_config:
                 model_kwargs["top_p"] = model_config["top_p"]
 


### PR DESCRIPTION
## Summary
- Reasoning models like `gpt-5.2-pro` do not support the `temperature` parameter and return a **400 Bad Request** when it is included
- `gpt-5.2-pro` only supports the **Responses API** (`/v1/responses`), not the Chat Completions API (`/v1/chat/completions`) — sending requests to chat completions returns a 404
- Added `gpt-5.2` and `gpt-5.2-pro` to `generator.json` with a `use_responses_api` flag for models that require the Responses API
- Made `temperature`/`top_p` conditional in `websocket_wiki.py` and `simple_chat.py` for the OpenAI provider, only including them when present in model config
- Added Responses API streaming code path using `client.responses.create(stream=True)` for flagged models, extracting text from `response.output_text.delta` events

## Test plan
- [x] Use `gpt-5.2-pro` as a custom model with OpenAI provider — works end-to-end
- [ ] Verify `gpt-5.2` still works (uses Chat Completions API with temperature: 1.0)
- [ ] Verify other OpenAI models (gpt-4o, gpt-5, etc.) still work with temperature as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)