### PR TITLE
fix: replace bare except clauses with Exception

### DIFF
--- a/api/rag.py
+++ b/api/rag.py
@@ -408,7 +408,7 @@ IMPORTANT FORMATTING RULES:
                             else:
                                 size = "unknown"
                             sizes.append(f"doc_{i}: {size}")
-                        except:
+                        except Exception:
                             sizes.append(f"doc_{i}: error")
                 logger.error(f"Sample embedding sizes: {', '.join(sizes)}")
             raise

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -911,5 +911,5 @@ This file contains...
         try:
             await websocket.send_text(f"Error: {str(e)}")
             await websocket.close()
-        except:
+        except Exception:
             pass


### PR DESCRIPTION
## Problem

Two bare `except:` clauses catch `BaseException`, which includes `SystemExit` and `KeyboardInterrupt`, preventing clean shutdown.

## Fix

Replace with `except Exception:` in:
- `api/rag.py` line 411: embedding size debug logging
- `api/websocket_wiki.py` line 914: WebSocket error cleanup