### PR TITLE
fix: Docker build font timeout and deprecated Google embedding model

### DIFF
--- a/api/config/embedder.json
+++ b/api/config/embedder.json
@@ -18,7 +18,7 @@
     "client_class": "GoogleEmbedderClient",
     "batch_size": 100,
     "model_kwargs": {
-      "model": "text-embedding-004",
+      "model": "gemini-embedding-001",
       "task_type": "SEMANTIC_SIMILARITY"
     }
   },

--- a/api/google_embedder_client.py
+++ b/api/google_embedder_client.py
@@ -39,7 +39,7 @@ class GoogleEmbedderClient(ModelClient):
         embedder = adal.Embedder(
             model_client=client,
             model_kwargs={
-                "model": "text-embedding-004",
+                "model": "gemini-embedding-001",
                 "task_type": "SEMANTIC_SIMILARITY"
             }
         )
@@ -47,7 +47,7 @@ class GoogleEmbedderClient(ModelClient):
 
     References:
         - Google AI Embeddings: https://ai.google.dev/gemini-api/docs/embeddings
-        - Available models: text-embedding-004, embedding-001
+        - Available models: gemini-embedding-001
     """
 
     def __init__(
@@ -199,7 +199,7 @@ class GoogleEmbedderClient(ModelClient):
             
         # Set default model if not provided
         if "model" not in final_model_kwargs:
-            final_model_kwargs["model"] = "text-embedding-004"
+            final_model_kwargs["model"] = "gemini-embedding-001"
             
         return final_model_kwargs
 
@@ -239,8 +239,10 @@ class GoogleEmbedderClient(ModelClient):
                 response = genai.embed_content(**api_kwargs)
             elif "contents" in api_kwargs:
                 # Batch embedding - Google AI supports batch natively
-                contents = api_kwargs.pop("contents")
-                response = genai.embed_content(content=contents, **api_kwargs)
+                # Copy to avoid mutating the original dict (needed for retries)
+                kwargs = api_kwargs.copy()
+                contents = kwargs.pop("contents")
+                response = genai.embed_content(content=contents, **kwargs)
             else:
                 raise ValueError("Either 'content' or 'contents' must be provided")
                 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -39,8 +39,11 @@ html[data-theme='dark'] {
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: 'Noto Sans JP', sans-serif;
+  --font-mono: 'Geist Mono', monospace;
+  --font-geist-sans: 'Noto Sans JP', sans-serif;
+  --font-geist-mono: 'Geist Mono', monospace;
+  --font-serif-jp: 'Noto Serif JP', serif;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,28 +1,7 @@
 import type { Metadata } from "next";
-import { Noto_Sans_JP, Noto_Serif_JP, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import { LanguageProvider } from "@/contexts/LanguageContext";
-
-// Japanese-friendly fonts
-const notoSansJP = Noto_Sans_JP({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-  weight: ["400", "500", "700"],
-  display: "swap",
-});
-
-const notoSerifJP = Noto_Serif_JP({
-  variable: "--font-serif-jp",
-  subsets: ["latin"],
-  weight: ["400", "500", "700"],
-  display: "swap",
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Deepwiki Open Source | Sheing Ng",
@@ -36,9 +15,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${notoSansJP.variable} ${notoSerifJP.variable} ${geistMono.variable} antialiased`}
-      >
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Geist+Mono&family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body className="antialiased">
         <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
           <LanguageProvider>
             {children}


### PR DESCRIPTION
## Summary

- **Fix Docker build failure**: Replace `next/font/google` (build-time download) with runtime `<link>` tags, eliminating `ETIMEDOUT` errors when building inside Docker where Google Fonts is unreachable
- **Fix Google embedding 404**: Migrate from deprecated `text-embedding-004` to `gemini-embedding-001` (removed from v1beta API on Jan 14, 2026)
- **Fix retry bug**: `api_kwargs.pop("contents")` mutated the shared dict, causing `@backoff` retries to always fail with `Either 'content' or 'contents' must be provided`

## Changed files

| File | Change |
|---|---|
| `src/app/layout.tsx` | `next/font/google` → runtime `<link>` Google Fonts loading |
| `src/app/globals.css` | Define font CSS variables in `@theme inline` (previously injected by `next/font`) |
| `api/config/embedder.json` | Model `text-embedding-004` → `gemini-embedding-001` |
| `api/google_embedder_client.py` | Model name update + fix dict mutation in `call()` |

## Test plan

- [ ] `docker compose up -d --build` completes without font timeout errors
- [ ] Wiki generation with Google embedder succeeds (no 404 or content errors)
- [ ] Batch embedding retries work correctly on transient failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)