### PR TITLE
Fix running Ollama in docker

### DIFF
--- a/Ollama-instruction.md
+++ b/Ollama-instruction.md
@@ -80,8 +80,14 @@ npm run dev
 
 ## Alternative using Dockerfile
 
-1. Build the docker image `docker build -f Dockerfile-ollama-local -t deepwiki:ollama-local .`
-2. Run the container:
+1. Configure the Local Embedder for Ollama:
+```
+cp api/config/embedder.ollama.json.bak api/config/embedder.json
+# overwrite api/config/embedder.json? (y/n [n]) y
+```
+
+2. Build the docker image `docker build -f Dockerfile-ollama-local -t deepwiki:ollama-local .`
+3. Run the container:
    ```bash
    # For regular use
    docker run -p 3000:3000 -p 8001:8001 --name deepwiki \
@@ -97,9 +103,9 @@ npm run dev
      deepwiki:ollama-local
    ```
 
-3. When using local repositories in the interface: use `/app/local-repos/repo-name` as the local repository path.
+4. When using local repositories in the interface: use `/app/local-repos/repo-name` as the local repository path.
 
-4. Open http://localhost:3000 in your browser
+5. Open http://localhost:3000 in your browser
 
 Note: For Apple Silicon Macs, the Dockerfile automatically uses ARM64 binaries for better performance.
 

--- a/api/config/embedder.ollama.json.bak
+++ b/api/config/embedder.ollama.json.bak
@@ -1,4 +1,10 @@
 {
+  "embedder_ollama": {
+    "client_class": "OllamaClient",
+    "model_kwargs": {
+      "model": "nomic-embed-text"
+    }
+  },
   "embedder": {
     "client_class": "OllamaClient",
     "model_kwargs": {


### PR DESCRIPTION
Fix running Ollama in docker. By fixing embedder configuration and Ollama instructions using Docker.

Fixes and closes #483 
