### PR TITLE
fix: rebuild database when custom file filters are provided

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -865,34 +865,41 @@ class DatabaseManager:
         # Handle backward compatibility
         if embedder_type is None and is_ollama_embedder is not None:
             embedder_type = 'ollama' if is_ollama_embedder else None
+        # Check if custom file filters are provided
+        has_custom_filters = any([excluded_dirs, excluded_files, included_dirs, included_files])
+
         # check the database
         if self.repo_paths and os.path.exists(self.repo_paths["save_db_file"]):
-            logger.info("Loading existing database...")
-            try:
-                self.db = LocalDB.load_state(self.repo_paths["save_db_file"])
-                documents = self.db.get_transformed_data(key="split_and_embed")
-                if documents:
-                    lengths = [_embedding_vector_length(doc) for doc in documents]
-                    non_empty = sum(1 for n in lengths if n > 0)
-                    empty = len(lengths) - non_empty
-                    sample_sizes = sorted({n for n in lengths if n > 0})[:3]
-                    logger.info(
-                        "Loaded %s documents from existing database (embeddings: %s non-empty, %s empty; sample_dims=%s)",
-                        len(documents),
-                        non_empty,
-                        empty,
-                        sample_sizes,
-                    )
-
-                    if non_empty == 0:
-                        logger.warning(
-                            "Existing database contains no usable embeddings. Rebuilding embeddings..."
+            if has_custom_filters:
+                logger.info("Custom file filters provided. Rebuilding database to apply filters...")
+                os.remove(self.repo_paths["save_db_file"])
+            else:
+                logger.info("Loading existing database...")
+                try:
+                    self.db = LocalDB.load_state(self.repo_paths["save_db_file"])
+                    documents = self.db.get_transformed_data(key="split_and_embed")
+                    if documents:
+                        lengths = [_embedding_vector_length(doc) for doc in documents]
+                        non_empty = sum(1 for n in lengths if n > 0)
+                        empty = len(lengths) - non_empty
+                        sample_sizes = sorted({n for n in lengths if n > 0})[:3]
+                        logger.info(
+                            "Loaded %s documents from existing database (embeddings: %s non-empty, %s empty; sample_dims=%s)",
+                            len(documents),
+                            non_empty,
+                            empty,
+                            sample_sizes,
                         )
-                    else:
-                        return documents
-            except Exception as e:
-                logger.error(f"Error loading existing database: {e}")
-                # Continue to create a new database
+
+                        if non_empty == 0:
+                            logger.warning(
+                                "Existing database contains no usable embeddings. Rebuilding embeddings..."
+                            )
+                        else:
+                            return documents
+                except Exception as e:
+                    logger.error(f"Error loading existing database: {e}")
+                    # Continue to create a new database
 
         # prepare the database
         logger.info("Creating new database...")


### PR DESCRIPTION
## Summary

- When custom file exclusion/inclusion parameters are provided via "Refresh Wiki" advanced options, the cached `.pkl` database is now removed and rebuilt with the new filters applied
- Previously, the cached database was returned immediately, silently ignoring all filter parameters

Fixes #494

## Changes

**`api/data_pipeline.py`** — `prepare_db_index()` method:
- Added a check for custom filter parameters (`excluded_dirs`, `excluded_files`, `included_dirs`, `included_files`) before loading cached database
- When custom filters are present, the existing `.pkl` cache file is deleted to force a rebuild with the new filters
- When no custom filters are provided, behavior is unchanged (cache is used as before)

## Test plan

- [ ] Index a repository without any exclusions
- [ ] Re-index the same repository with `README.md` in the excluded files list
- [ ] Verify the regenerated wiki does not reference `README.md`
- [ ] Verify that re-indexing without exclusions still uses the cached database (check logs for "Loading existing database...")

🤖 Generated with [Claude Code](https://claude.com/claude-code)