### PR TITLE
fix: update Bitbucket clone auth to use API token scheme

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -116,8 +116,11 @@ def download_repo(repo_url: str, local_path: str, repo_type: str = None, access_
                 # Format: https://oauth2:{token}@gitlab.com/owner/repo.git
                 clone_url = urlunparse((parsed.scheme, f"oauth2:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
             elif repo_type == "bitbucket":
-                # Format: https://x-token-auth:{token}@bitbucket.org/owner/repo.git
-                clone_url = urlunparse((parsed.scheme, f"x-token-auth:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
+                # Format: https://x-bitbucket-api-token-auth:{token}@bitbucket.org/owner/repo.git
+                # Bitbucket HTTP access tokens require the x-bitbucket-api-token-auth scheme.
+                # The older x-token-auth scheme was used for app passwords, which are being
+                # deprecated by Atlassian (EOL June 2026).
+                clone_url = urlunparse((parsed.scheme, f"x-bitbucket-api-token-auth:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
 
             logger.info("Using access token for authentication")
 

--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -116,11 +116,16 @@ def download_repo(repo_url: str, local_path: str, repo_type: str = None, access_
                 # Format: https://oauth2:{token}@gitlab.com/owner/repo.git
                 clone_url = urlunparse((parsed.scheme, f"oauth2:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
             elif repo_type == "bitbucket":
-                # Format: https://x-bitbucket-api-token-auth:{token}@bitbucket.org/owner/repo.git
-                # Bitbucket HTTP access tokens require the x-bitbucket-api-token-auth scheme.
-                # The older x-token-auth scheme was used for app passwords, which are being
-                # deprecated by Atlassian (EOL June 2026).
-                clone_url = urlunparse((parsed.scheme, f"x-bitbucket-api-token-auth:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
+                # Bitbucket has two token formats with different auth schemes:
+                #   - HTTP access tokens (prefix "ATCTT") use x-bitbucket-api-token-auth
+                #   - App passwords (deprecated, EOL June 2026) use x-token-auth
+                # Detect by token prefix so existing app password users keep working.
+                if access_token.startswith("ATCTT"):
+                    auth_scheme = "x-bitbucket-api-token-auth"
+                else:
+                    auth_scheme = "x-token-auth"
+                # Format: https://{auth_scheme}:{token}@bitbucket.org/owner/repo.git
+                clone_url = urlunparse((parsed.scheme, f"{auth_scheme}:{encoded_token}@{parsed.netloc}", parsed.path, '', '', ''))
 
             logger.info("Using access token for authentication")
 


### PR DESCRIPTION
Fixes #444

## Problem

When cloning private Bitbucket repositories, the application uses the `x-token-auth` authentication scheme (designed for Bitbucket app passwords). However, Bitbucket is deprecating app passwords (EOL June 2026) and has already removed the ability to create new ones from the normal user panel. New users can only generate HTTP access tokens, which require the `x-bitbucket-api-token-auth` scheme instead.

This mismatch causes authentication to fail with a 401 error even when the token is valid and can be used to clone the repository manually.

**Relevant code** (`api/data_pipeline.py` line 120):
```python
# Before (broken for API tokens):
clone_url = urlunparse((parsed.scheme, f"x-token-auth:{encoded_token}@{parsed.netloc}", ...))

# After (works with current Bitbucket HTTP access tokens):
clone_url = urlunparse((parsed.scheme, f"x-bitbucket-api-token-auth:{encoded_token}@{parsed.netloc}", ...))
```

## Solution

Updated the Bitbucket clone URL format to use `x-bitbucket-api-token-auth`, the authentication scheme required by Bitbucket HTTP access tokens.

## Testing

Confirmed that `x-bitbucket-api-token-auth` is the correct scheme per [Atlassian's documentation](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/) for HTTP access tokens.