### PR TITLE
fix: surface actual API errors instead of generic 'No valid XML' message

### DIFF
--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -945,6 +945,15 @@ IMPORTANT:
       // Extract wiki structure from response
       const xmlMatch = responseText.match(/<wiki_structure>[\s\S]*?<\/wiki_structure>/m);
       if (!xmlMatch) {
+        // Surface the actual API error instead of a generic message
+        const apiErrorMatch = responseText.match(/Error with [\w][\w ]*API:\s*[^\n]+/);
+        if (apiErrorMatch) {
+          throw new Error(apiErrorMatch[0].trim());
+        }
+        const generalErrorMatch = responseText.match(/\nError:\s*[^\n]+/);
+        if (generalErrorMatch) {
+          throw new Error(generalErrorMatch[0].trim());
+        }
         throw new Error('No valid XML found in response');
       }
 


### PR DESCRIPTION
Fixes #493

## Problem

When wiki generation fails due to upstream API errors (e.g. rate limiting 429), the frontend only shows a generic message:

> **No valid XML found in response**
> Please check that your repository exists and is public...

The actual error (e.g. `Error code: 429 - RPM limit reached`) is only visible in container logs, making debugging very difficult. Users are misled into thinking their repository URL is wrong.

## Solution

After the existing specific error checks (OPENAI_API_KEY missing, Ollama model not found), before throwing the generic error, the code now attempts to extract and surface the actual API error message from the response text:

1. First checks for provider-specific errors matching `Error with <Provider> API: <message>` (e.g. `Error with Openai API: Error code: 429 - ...`)
2. Falls back to checking for general `\nError: <message>` patterns
3. Only falls back to the generic `'No valid XML found in response'` if no API error is detected

## Testing

- When an API returns a rate limit error (429), users will now see `Error with Openai API: Error code: 429 - {'error': {'message': 'RPM limit reached'}}` instead of the misleading generic message
- Existing behavior is preserved for cases where no API error is present (e.g. true XML parsing failures)
- The existing specific error checks (missing API key, Ollama model not found) are unaffected