### PR TITLE
fix(docker): use Debian-provided Node.js instead of NodeSource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,17 +39,13 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
-# Install Node.js and npm
+# Install Node.js and npm from Debian repos (avoids NodeSource TLS issues)
 RUN apt-get update && apt-get install -y \
     curl \
-    gnupg \
     git \
     ca-certificates \
-    && mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
-    && apt-get install -y nodejs \
+    nodejs \
+    npm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The previous Dockerfile installed Node.js by adding the NodeSource APT repository, which requires fetching the GPG key over HTTPS from deb.nodesource.com during the build. In some network environments this TLS connection fails with:

  curl: (35) TLS connect error: error:0A000126:SSL routines::
  unexpected eof while reading

Since Debian Trixie (the base of python:3.11-slim) already ships Node.js 20.x in its main repositories, we can install it directly via apt without depending on NodeSource. This makes the build more reliable and removes the gnupg/keyring setup entirely.