### PR TITLE
fix: preserve full path in repo cache key for GitLab subgroup URLs (#438, #439)

### DIFF
--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -769,17 +769,31 @@ class DatabaseManager:
 
     def _extract_repo_name_from_url(self, repo_url_or_path: str, repo_type: str) -> str:
         # Extract owner and repo name to create unique identifier
-        url_parts = repo_url_or_path.rstrip('/').split('/')
+        repo_url_or_path = repo_url_or_path.strip().rstrip('/')
 
-        if repo_type in ["github", "gitlab", "bitbucket"] and len(url_parts) >= 5:
-            # GitHub URL format: https://github.com/owner/repo
-            # GitLab URL format: https://gitlab.com/owner/repo or https://gitlab.com/group/subgroup/repo
-            # Bitbucket URL format: https://bitbucket.org/owner/repo
-            owner = url_parts[-2]
-            repo = url_parts[-1].replace(".git", "")
-            repo_name = f"{owner}_{repo}"
+        def strip_git_suffix(name: str) -> str:
+            return name[:-4] if name.endswith(".git") else name
+
+        if repo_type in ["github", "gitlab", "bitbucket"]:
+            parsed_url = urlparse(repo_url_or_path)
+            if parsed_url.scheme and parsed_url.netloc:
+                path_parts = [part for part in parsed_url.path.strip('/').split('/') if part]
+            else:
+                path = repo_url_or_path.split('?', 1)[0].split('#', 1)[0].strip('/')
+                path_parts = [part for part in path.split('/') if part]
+                if len(path_parts) >= 3:
+                    host = path_parts[0].lower()
+                    if "." in host or host == "localhost":
+                        path_parts = path_parts[1:]
+
+            if len(path_parts) >= 2:
+                path_parts[-1] = strip_git_suffix(path_parts[-1])
+                repo_name = "_".join(path_parts)
+            else:
+                repo_name = strip_git_suffix(path_parts[-1]) if path_parts else ""
         else:
-            repo_name = url_parts[-1].replace(".git", "")
+            url_parts = repo_url_or_path.split('/')
+            repo_name = strip_git_suffix(url_parts[-1])
         return repo_name
 
     def _create_repo(self, repo_url_or_path: str, repo_type: str = None, access_token: str = None) -> None:

--- a/api/data_pipeline.py
+++ b/api/data_pipeline.py
@@ -786,11 +786,11 @@ class DatabaseManager:
                     if "." in host or host == "localhost":
                         path_parts = path_parts[1:]
 
-            if len(path_parts) >= 2:
+            if path_parts:
                 path_parts[-1] = strip_git_suffix(path_parts[-1])
                 repo_name = "_".join(path_parts)
             else:
-                repo_name = strip_git_suffix(path_parts[-1]) if path_parts else ""
+                repo_name = ""
         else:
             url_parts = repo_url_or_path.split('/')
             repo_name = strip_git_suffix(url_parts[-1])
@@ -832,7 +832,7 @@ class DatabaseManager:
                 else:
                     logger.info(f"Repository already exists at {save_repo_dir}. Using existing repository.")
             else:  # local path
-                repo_name = os.path.basename(repo_url_or_path)
+                repo_name = self._extract_repo_name_from_url(repo_url_or_path, repo_type)
                 save_repo_dir = repo_url_or_path
 
             save_db_file = os.path.join(root_path, "databases", f"{repo_name}.pkl")

--- a/test/test_extract_repo_name.py
+++ b/test/test_extract_repo_name.py
@@ -55,7 +55,7 @@ class TestExtractRepoNameFromUrl:
         # Test GitLab URL with subgroups
         gitlab_subgroup = "https://gitlab.com/group/subgroup/repo"
         result = self.db_manager._extract_repo_name_from_url(gitlab_subgroup, "gitlab")
-        assert result == "subgroup_repo"
+        assert result == "group_subgroup_repo"
         
         print("✓ GitLab URL tests passed")
     


### PR DESCRIPTION
Addresses the cache-key half of #438 (and related #439).

The previous `_extract_repo_name_from_url` (api/data_pipeline.py:773) collapsed `https://gitlab.com/group/subgroup/repo` down to a cache key of `subgroup_repo`. Two different parent groups with the same `project/subproject` last-two-segments would collide on `~/.adalflow/databases/{key}.pkl` even though the clone URL itself was passed through intact.

This PR switches to `urlparse` and joins every path segment with underscores:

| URL | Old key | New key |
|-----|---------|---------|
| `github.com/owner/repo` | `owner_repo` | `owner_repo` (unchanged) |
| `bitbucket.org/owner/repo` | `owner_repo` | `owner_repo` (unchanged) |
| `gitlab.com/owner/repo` | `owner_repo` | `owner_repo` (unchanged) |
| `gitlab.com/group/subgroup/repo` | `subgroup_repo` | `group_subgroup_repo` |
| `gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap` | `gems_prometheus-client-mmap` | `gitlab-org_ruby_gems_prometheus-client-mmap` |

The existing GitLab subgroup test case is updated to reflect the new shape. Other test cases (2-segment URLs) keep their existing expectations.

**Scope note.** The reporter on #438/#439 says the URL "fails" even after being entered correctly. Running a GitLab subgroup URL through the frontend regex shows it's accepted (the lazy mid-group capture handles arbitrary depth), so the user-visible failure is downstream of input parsing. The cache-key fix here is the most localized, demonstrably-correct piece of that puzzle. If the reporter's failure persists after this lands, the next step is to repro `https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap` end-to-end and trace where wiki generation actually fails (likely in the clone or chat pipeline, not the cache).

Existing users with cached `subgroup_repo` databases will need to regenerate the wiki once after this lands; the new cache key won't match the old file. There are no schema migrations needed.

Relates to #438, #439