### PR TITLE
docs: update translated READMEs to reference Poetry instead of requirements.txt

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -158,7 +158,8 @@ deepwiki/
 │   ├── api.py            # Implementación FastAPI
 │   ├── rag.py            # Generación Aumentada por Recuperación
 │   ├── data_pipeline.py  # Utilidades de procesamiento de datos
-│   └── requirements.txt  # Dependencias Python
+│   ├── pyproject.toml     # Dependencias Python (Poetry)
+│   └── poetry.lock        # Versiones bloqueadas de dependencias Python
 │
 ├── src/                  # App frontend Next.js
 │   ├── app/              # Directorio app de Next.js

--- a/README.fr.md
+++ b/README.fr.md
@@ -168,7 +168,8 @@ deepwiki/
 │   ├── api.py            # Implémentation FastAPI
 │   ├── rag.py            # Génération Augmentée par Récupération (RAG)
 │   ├── data_pipeline.py  # Utilitaires de traitement des données
-│   └── requirements.txt  # Dépendances Python
+│   ├── pyproject.toml     # Dépendances Python (Poetry)
+│   └── poetry.lock        # Versions verrouillées des dépendances Python
 │
 ├── src/                  # Application Frontend Next.js
 │   ├── app/              # Répertoire de l'application Next.js

--- a/README.ja.md
+++ b/README.ja.md
@@ -160,7 +160,8 @@ deepwiki/
 │   ├── api.py            # FastAPI実装
 │   ├── rag.py            # 検索拡張生成
 │   ├── data_pipeline.py  # データ処理ユーティリティ
-│   └── requirements.txt  # Python依存関係
+│   ├── pyproject.toml     # Python依存関係 (Poetry)
+│   └── poetry.lock        # 固定されたPython依存関係バージョン
 │
 ├── src/                  # フロントエンドNext.jsアプリ
 │   ├── app/              # Next.jsアプリディレクトリ

--- a/README.kr.md
+++ b/README.kr.md
@@ -151,7 +151,8 @@ deepwiki/
 │   ├── api.py            # FastAPI 구현
 │   ├── rag.py            # Retrieval Augmented Generation
 │   ├── data_pipeline.py  # 데이터 처리 유틸리티
-│   └── requirements.txt  # Python 의존성
+│   ├── pyproject.toml     # Python 의존성 (Poetry)
+│   └── poetry.lock        # 잠긴 Python 의존성 버전
 │
 ├── src/                  # 프론트엔드 Next.js 앱
 │   ├── app/              # Next.js 앱 디렉토리

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -157,7 +157,8 @@ deepwiki/
 │   ├── api.py            # Implementação FastAPI
 │   ├── rag.py            # Retrieval Augmented Generation
 │   ├── data_pipeline.py  # Utilitários de processamento de dados
-│   └── requirements.txt  # Dependências Python
+│   ├── pyproject.toml     # Dependências Python (Poetry)
+│   └── poetry.lock        # Versões fixas de dependências Python
 │
 ├── src/                  # Aplicativo Next.js frontend
 │   ├── app/              # Diretório do aplicativo Next.js

--- a/README.ru.md
+++ b/README.ru.md
@@ -167,7 +167,8 @@ deepwiki/
 │   ├── api.py            # Реализация через FastAPI
 │   ├── rag.py            # RAG: генерация с дополнением
 │   ├── data_pipeline.py  # Утилиты обработки данных
-│   └── requirements.txt  # Зависимости Python
+│   ├── pyproject.toml     # Зависимости Python (Poetry)
+│   └── poetry.lock        # Зафиксированные версии зависимостей Python
 │
 ├── src/                  # Клиентское приложение на Next.js
 │   ├── app/              # Каталог приложения Next.js

--- a/README.vi.md
+++ b/README.vi.md
@@ -151,7 +151,8 @@ deepwiki/
 │   ├── api.py            # FastAPI
 │   ├── rag.py            # Retrieval Augmented Generation (RAG)
 │   ├── data_pipeline.py  # Data processing utilities
-│   └── requirements.txt  # Python dependencies
+│   ├── pyproject.toml     # Python dependencies (Poetry)
+│   └── poetry.lock        # Locked Python dependency versions
 │
 ├── src/                  # Frontend Next.js app
 │   ├── app/              # Next.js app directory

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -164,7 +164,8 @@ deepwiki/
 │   ├── api.py            # FastAPI 實作
 │   ├── rag.py            # 檢索增強產生
 │   ├── data_pipeline.py  # 資料處理工具
-│   └── requirements.txt  # Python 相依性
+│   ├── pyproject.toml     # Python 相依性 (Poetry)
+│   └── poetry.lock        # 已鎖定的 Python 相依性版本
 │
 ├── src/                  # 前端 Next.js 應用
 │   ├── app/              # Next.js 應用目錄

--- a/README.zh.md
+++ b/README.zh.md
@@ -158,7 +158,8 @@ deepwiki/
 │   ├── api.py            # FastAPI实现
 │   ├── rag.py            # 检索增强生成
 │   ├── data_pipeline.py  # 数据处理工具
-│   └── requirements.txt  # Python依赖
+│   ├── pyproject.toml     # Python依赖 (Poetry)
+│   └── poetry.lock        # 已锁定的 Python 依赖版本
 │
 ├── src/                  # 前端Next.js应用
 │   ├── app/              # Next.js应用目录


### PR DESCRIPTION
## Summary

The 9 translated READMEs still show `requirements.txt` in their project-structure tree. The repo migrated to Poetry in #380 and PR #433 updated only the English README to match (`pyproject.toml` + `poetry.lock`). This patch brings the translated structure trees in line.

## Why this matters

[#502](https://github.com/AsyncFuncAI/deepwiki-open/issues/502) flagged that the `api/` directory has no `requirements.txt`. The English README is correct; the 9 translated READMEs still list it, which sends readers looking for a file that does not exist.

## Changes

For each translated README, the single line:

```
│   └── requirements.txt  # <translated phrase>
```

is replaced with the two-line layout that already exists in the English README:

```
│   ├── pyproject.toml     # <translated phrase> (Poetry)
│   └── poetry.lock        # <translated phrase, locked dep versions>
```

Per-language comments translate "Python dependencies (Poetry)" and "Locked Python dependency versions" into the same register the file already uses. `README.vi.md` keeps English text for this entry, matching the prior line's existing style.

## Testing

Docs-only change. No test runner invoked. Spot-checked the tree alignment in each file.

## Notes

Touches the same 9 translated READMEs as the open #508 (docker-compose v1 → v2), but on different lines (project-structure tree vs docker-compose command). Can merge in either order; will rebase if #508 lands first.

Closes #502

AI was used for assistance.
