### PR TITLE
fix: guard against empty/filtered LLM responses in get_first_message_content

### DIFF
--- a/api/azureai_client.py
+++ b/api/azureai_client.py
@@ -75,6 +75,8 @@ __all__ = ["AzureAIClient"]
 def get_first_message_content(completion: ChatCompletion) -> str:
     r"""When we only need the content of the first message.
     It is the default parser for chat completion."""
+    if not completion.choices or completion.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return completion.choices[0].message.content
 
 

--- a/api/azureai_client.py
+++ b/api/azureai_client.py
@@ -75,7 +75,11 @@ __all__ = ["AzureAIClient"]
 def get_first_message_content(completion: ChatCompletion) -> str:
     r"""When we only need the content of the first message.
     It is the default parser for chat completion."""
-    if not completion.choices or completion.choices[0].message is None:
+    if (
+        not completion.choices
+        or completion.choices[0].message is None
+        or completion.choices[0].message.content is None
+    ):
         raise ValueError("LLM returned empty or filtered response")
     return completion.choices[0].message.content
 

--- a/api/openai_client.py
+++ b/api/openai_client.py
@@ -59,7 +59,11 @@ def get_first_message_content(completion: ChatCompletion) -> str:
     r"""When we only need the content of the first message.
     It is the default parser for chat completion."""
     log.debug(f"raw completion: {completion}")
-    if not completion.choices or completion.choices[0].message is None:
+    if (
+        not completion.choices
+        or completion.choices[0].message is None
+        or completion.choices[0].message.content is None
+    ):
         raise ValueError("LLM returned empty or filtered response")
     return completion.choices[0].message.content
 

--- a/api/openai_client.py
+++ b/api/openai_client.py
@@ -59,6 +59,8 @@ def get_first_message_content(completion: ChatCompletion) -> str:
     r"""When we only need the content of the first message.
     It is the default parser for chat completion."""
     log.debug(f"raw completion: {completion}")
+    if not completion.choices or completion.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return completion.choices[0].message.content
 
 


### PR DESCRIPTION
## What

Add null checks in `api/openai_client.py` and `api/azureai_client.py` before accessing `choices[0].message.content` in `get_first_message_content`.

## Why

Two crash vectors exist:

1. **`IndexError`** — when `choices` is empty (network interruption, provider edge cases returning HTTP 200 with empty body)
2. **`AttributeError`** — when `choices[0].message` is `None`. Observed on Gemini via OpenAI-compatible endpoint on PROHIBITED_CONTENT (HTTP 200 with `message: null`)

## Fix

```python
if not completion.choices or completion.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return completion.choices[0].message.content
```

No behaviour change for well-formed responses.