### PR TITLE
[AI-Generated] feat: auto-discover models from custom OpenAI-compatible endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,45 @@ https://github.com/user-attachments/assets/48d1e60a-eb91-4c05-a5a8-3624ffb79fb1
 
 
 
+## 🔌 Custom OpenAI-Compatible Endpoints (llama.cpp, vLLM, LocalAI, etc.)
+
+DeepWiki supports using any OpenAI-compatible API as the LLM backend. This is
+ideal for self-hosted models via llama.cpp, vLLM, text-generation-webui, LocalAI,
+or any other server that exposes the OpenAI API format.
+
+### Configuration
+
+Set the following environment variables:
+
+```bash
+OPENAI_BASE_URL=http://your-host:port/v1   # Your OpenAI-compatible endpoint
+OPENAI_API_KEY=dummy                         # Required by the client but not validated by most local servers
+```
+
+### Automatic Model Discovery
+
+When `OPENAI_BASE_URL` is set, DeepWiki will automatically query the endpoint's
+`/v1/models` API to discover available models. The discovered models are then
+shown in the UI's model selector dropdown — no manual editing of `generator.json`
+is required.
+
+If the `/v1/models` endpoint is unreachable or returns an error, DeepWiki
+gracefully falls back to the statically configured models in `generator.json`.
+
+### Example: llama.cpp
+
+```bash
+# Start llama.cpp server
+./llama-server -m your-model.gguf --port 8000
+
+# Configure DeepWiki
+export OPENAI_BASE_URL=http://localhost:8000/v1
+export OPENAI_API_KEY=dummy
+```
+
+The model loaded in llama.cpp will automatically appear in DeepWiki's model
+selector as the available option under the "Openai" provider.
+
 ## 🤝 Contributing
 
 Contributions are welcome! Feel free to:

--- a/api/api.py
+++ b/api/api.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 import google.generativeai as genai
 import asyncio
+import aiohttp
 
 # Configure logging
 from api.logging_config import setup_logging
@@ -164,6 +165,40 @@ async def validate_auth_code(request: AuthorizationConfig):
     """
     return {"success": WIKI_AUTH_CODE == request.code}
 
+async def _discover_openai_models(base_url: str) -> List[Model]:
+    """
+    Query a custom OpenAI-compatible endpoint's /models API to discover available models.
+
+    Args:
+        base_url: The base URL of the OpenAI-compatible API (e.g., http://host:port/v1)
+
+    Returns:
+        List of Model objects discovered from the endpoint, or empty list on failure.
+    """
+    # Normalize: strip trailing /v1 if present since we'll add /models
+    models_url = f"{base_url.rstrip('/')}/models"
+
+    try:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+            async with session.get(models_url) as response:
+                response.raise_for_status()
+                data = await response.json()
+
+                discovered = []
+                # OpenAI /v1/models returns {"data": [{"id": "model-name", ...}, ...]}
+                for model_info in data.get("data", []):
+                    model_id = model_info.get("id", "")
+                    if model_id:
+                        discovered.append(Model(id=model_id, name=model_id))
+
+                if discovered:
+                    logger.info(f"Discovered {len(discovered)} models from {models_url}")
+                return discovered
+    except Exception as e:
+        logger.warning(f"Failed to discover models from {models_url}: {e}")
+        return []
+
+
 @app.get("/models/config", response_model=ModelConfig)
 async def get_model_config():
     """
@@ -172,11 +207,19 @@ async def get_model_config():
     This endpoint returns the configuration of available model providers and their
     respective models that can be used throughout the application.
 
+    When OPENAI_BASE_URL is set (indicating a custom OpenAI-compatible endpoint such as
+    llama.cpp, vLLM, or LocalAI), the openai provider's model list is dynamically
+    discovered by querying the endpoint's /models API. This allows automatic detection
+    of locally hosted models without manual configuration.
+
     Returns:
         ModelConfig: A configuration object containing providers and their models
     """
     try:
         logger.info("Fetching model configurations")
+
+        # Check if a custom OpenAI endpoint is configured
+        openai_base_url = os.environ.get("OPENAI_BASE_URL")
 
         # Create providers from the config file
         providers = []
@@ -185,10 +228,20 @@ async def get_model_config():
         # Add provider configuration based on config.py
         for provider_id, provider_config in configs["providers"].items():
             models = []
-            # Add models from config
-            for model_id in provider_config["models"].keys():
-                # Get a more user-friendly display name if possible
-                models.append(Model(id=model_id, name=model_id))
+
+            # For the openai provider with a custom base URL, discover models dynamically
+            if provider_id == "openai" and openai_base_url:
+                discovered = await _discover_openai_models(openai_base_url)
+                if discovered:
+                    models = discovered
+                else:
+                    # Fall back to static config if discovery fails
+                    for model_id in provider_config["models"].keys():
+                        models.append(Model(id=model_id, name=model_id))
+            else:
+                # Add models from config
+                for model_id in provider_config["models"].keys():
+                    models.append(Model(id=model_id, name=model_id))
 
             # Add provider with its models
             providers.append(

--- a/api/api.py
+++ b/api/api.py
@@ -178,18 +178,26 @@ async def _discover_openai_models(base_url: str) -> List[Model]:
     # Normalize: strip trailing /v1 if present since we'll add /models
     models_url = f"{base_url.rstrip('/')}/models"
 
+    # Pass API key if available (some endpoints require auth even for /models)
+    headers = {}
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
     try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
-            async with session.get(models_url) as response:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
+            async with session.get(models_url, headers=headers) as response:
                 response.raise_for_status()
                 data = await response.json()
 
                 discovered = []
-                # OpenAI /v1/models returns {"data": [{"id": "model-name", ...}, ...]}
-                for model_info in data.get("data", []):
-                    model_id = model_info.get("id", "")
-                    if model_id:
-                        discovered.append(Model(id=model_id, name=model_id))
+                if isinstance(data, dict):
+                    # OpenAI /v1/models returns {"data": [{"id": "model-name", ...}, ...]}
+                    for model_info in data.get("data", []):
+                        if isinstance(model_info, dict):
+                            model_id = model_info.get("id", "")
+                            if model_id:
+                                discovered.append(Model(id=model_id, name=model_id))
 
                 if discovered:
                     logger.info(f"Discovered {len(discovered)} models from {models_url}")

--- a/tests/unit/test_model_discovery.py
+++ b/tests/unit/test_model_discovery.py
@@ -1,0 +1,141 @@
+"""
+Tests for the dynamic model discovery feature.
+
+When OPENAI_BASE_URL is set, the /models/config endpoint should query
+the custom endpoint's /v1/models API to discover available models instead
+of using the static generator.json configuration.
+"""
+
+import os
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+from contextlib import asynccontextmanager
+
+# We test the helper function directly
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+@pytest.fixture
+def mock_openai_models_response():
+    """Typical response from an OpenAI-compatible /v1/models endpoint."""
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "my-local-model",
+                "object": "model",
+                "created": 1700000000,
+                "owned_by": "system"
+            },
+            {
+                "id": "another-model-7b",
+                "object": "model",
+                "created": 1700000001,
+                "owned_by": "system"
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_discover_models_success(mock_openai_models_response):
+    """Test successful model discovery from a custom endpoint."""
+    from api.api import _discover_openai_models, Model
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(return_value=mock_openai_models_response)
+
+    @asynccontextmanager
+    async def mock_get(*args, **kwargs):
+        yield mock_response
+
+    mock_session = AsyncMock()
+    mock_session.get = mock_get
+
+    @asynccontextmanager
+    async def mock_client_session(*args, **kwargs):
+        yield mock_session
+
+    with patch('api.api.aiohttp.ClientSession', mock_client_session):
+        models = await _discover_openai_models("http://localhost:8000/v1")
+
+    assert len(models) == 2
+    assert models[0].id == "my-local-model"
+    assert models[1].id == "another-model-7b"
+
+
+@pytest.mark.asyncio
+async def test_discover_models_failure_returns_empty():
+    """Test that discovery failure returns empty list (graceful fallback)."""
+    from api.api import _discover_openai_models
+
+    @asynccontextmanager
+    async def mock_client_session(*args, **kwargs):
+        raise ConnectionError("Connection refused")
+        yield  # noqa: unreachable
+
+    with patch('api.api.aiohttp.ClientSession', mock_client_session):
+        models = await _discover_openai_models("http://unreachable:8000/v1")
+
+    assert models == []
+
+
+@pytest.mark.asyncio
+async def test_discover_models_empty_data():
+    """Test that an empty model list from the endpoint returns empty."""
+    from api.api import _discover_openai_models
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(return_value={"data": []})
+
+    @asynccontextmanager
+    async def mock_get(*args, **kwargs):
+        yield mock_response
+
+    mock_session = AsyncMock()
+    mock_session.get = mock_get
+
+    @asynccontextmanager
+    async def mock_client_session(*args, **kwargs):
+        yield mock_session
+
+    with patch('api.api.aiohttp.ClientSession', mock_client_session):
+        models = await _discover_openai_models("http://localhost:8000/v1")
+
+    assert models == []
+
+
+@pytest.mark.asyncio
+async def test_discover_models_url_construction():
+    """Test that the /models URL is correctly constructed from base_url."""
+    from api.api import _discover_openai_models
+
+    called_urls = []
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(return_value={"data": [{"id": "test"}]})
+
+    @asynccontextmanager
+    async def mock_get(url, *args, **kwargs):
+        called_urls.append(url)
+        yield mock_response
+
+    mock_session = AsyncMock()
+    mock_session.get = mock_get
+
+    @asynccontextmanager
+    async def mock_client_session(*args, **kwargs):
+        yield mock_session
+
+    with patch('api.api.aiohttp.ClientSession', mock_client_session):
+        # With trailing slash
+        await _discover_openai_models("http://localhost:8000/v1/")
+        # Without trailing slash
+        await _discover_openai_models("http://localhost:8000/v1")
+
+    assert called_urls[0] == "http://localhost:8000/v1/models"
+    assert called_urls[1] == "http://localhost:8000/v1/models"


### PR DESCRIPTION
## ⚠️ Disclosure

**This PR was fully AI-generated** (code, tests, documentation, and this PR description) using Claude (Anthropic) via Hermes Agent. A human reviewed and approved the intent and final result, but did not write any of the code manually.

---

## Summary

When `OPENAI_BASE_URL` is set (indicating a custom OpenAI-compatible endpoint), the `/models/config` API endpoint now dynamically discovers available models by querying the endpoint's `/v1/models` API.

This enables seamless integration with self-hosted LLM servers like **llama.cpp**, **vLLM**, **LocalAI**, and **text-generation-webui** without requiring manual model configuration in `generator.json`.

## Changes

- **`api/api.py`**: Add `_discover_openai_models()` async helper + modify `get_model_config()` to use it for the `openai` provider when `OPENAI_BASE_URL` is set
- **`tests/unit/test_model_discovery.py`**: Unit tests for discovery success, failure fallback, empty response, and URL construction
- **`README.md`**: Document custom endpoint configuration and automatic model discovery

## Behavior

| Condition | Result |
|-----------|--------|
| `OPENAI_BASE_URL` not set | Uses `generator.json` models (unchanged) |
| `OPENAI_BASE_URL` set + endpoint reachable | Discovers models from `/v1/models` |
| `OPENAI_BASE_URL` set + endpoint unreachable | Logs warning, falls back to `generator.json` |

## Example

```bash
# llama.cpp server running locally
export OPENAI_BASE_URL=http://localhost:8000/v1
export OPENAI_API_KEY=dummy
```

The model loaded in llama.cpp will automatically appear in the UI dropdown.

## No new dependencies

Uses `aiohttp` which is already in the project's dependencies.