### PR TITLE
Preload tiktoken encoding cache in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,12 @@ RUN if [ -n "${CUSTOM_CERT_DIR}" ]; then \
     fi
 
 ENV PATH="/opt/venv/bin:$PATH"
+ENV TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache/
 
 # Copy Python dependencies
 COPY --from=py_deps /api/.venv /opt/venv
+RUN mkdir -p "$TIKTOKEN_CACHE_DIR" && \
+    python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 COPY api/ ./api/
 
 # Copy Node app

--- a/Dockerfile-litellm
+++ b/Dockerfile-litellm
@@ -72,9 +72,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"
+ENV TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache/
 
 # Copy Python dependencies
 COPY --from=py_deps /api/.venv /opt/venv
+RUN mkdir -p "$TIKTOKEN_CACHE_DIR" && \
+    python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 COPY api/ ./api/
 
 # Copy Node app

--- a/Dockerfile-ollama-local
+++ b/Dockerfile-ollama-local
@@ -71,9 +71,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"
+ENV TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache/
 
 # Copy Python dependencies
 COPY --from=py_deps /api/.venv /opt/venv
+RUN mkdir -p "$TIKTOKEN_CACHE_DIR" && \
+    python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 COPY api/ ./api/
 
 # Copy Node app


### PR DESCRIPTION
Set TIKTOKEN_CACHE_DIR and warm cl100k_base during image build so runtime token counting does not need to download encoding data in offline environments.

fix [#228](https://github.com/AsyncFuncAI/deepwiki-open/issues/228) [#259](https://github.com/AsyncFuncAI/deepwiki-open/issues/259)