### PR TITLE
Feature: Introduce LiteLLM client for multi-provider model routing

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8,6 +8,7 @@ from typing import List, Union, Dict, Any
 logger = logging.getLogger(__name__)
 
 from api.openai_client import OpenAIClient
+from api.litellm_client import LiteLLMClient
 from api.openrouter_client import OpenRouterClient
 from api.bedrock_client import BedrockClient
 from api.google_embedder_client import GoogleEmbedderClient
@@ -17,6 +18,7 @@ from adalflow import GoogleGenAIClient, OllamaClient
 
 # Get API keys from environment variables
 OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
+LITELLM_API_KEY = os.environ.get('LITELLM_API_KEY')
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')
 OPENROUTER_API_KEY = os.environ.get('OPENROUTER_API_KEY')
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
@@ -28,6 +30,8 @@ AWS_ROLE_ARN = os.environ.get('AWS_ROLE_ARN')
 # Set keys in environment (in case they're needed elsewhere in the code)
 if OPENAI_API_KEY:
     os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
+if LITELLM_API_KEY:
+    os.environ["LITELLM_API_KEY"] = LITELLM_API_KEY
 if GOOGLE_API_KEY:
     os.environ["GOOGLE_API_KEY"] = GOOGLE_API_KEY
 if OPENROUTER_API_KEY:
@@ -59,6 +63,7 @@ CLIENT_CLASSES = {
     "GoogleGenAIClient": GoogleGenAIClient,
     "GoogleEmbedderClient": GoogleEmbedderClient,
     "OpenAIClient": OpenAIClient,
+    "LiteLLMClient" : LiteLLMClient,
     "OpenRouterClient": OpenRouterClient,
     "OllamaClient": OllamaClient,
     "BedrockClient": BedrockClient,
@@ -131,10 +136,11 @@ def load_generator_config():
             if provider_config.get("client_class") in CLIENT_CLASSES:
                 provider_config["model_client"] = CLIENT_CLASSES[provider_config["client_class"]]
             # Fall back to default mapping based on provider_id
-            elif provider_id in ["google", "openai", "openrouter", "ollama", "bedrock", "azure", "dashscope"]:
+            elif provider_id in ["google", "openai", "openrouter", "ollama", "bedrock", "azure", "dashscope", "litellm"]:
                 default_map = {
                     "google": GoogleGenAIClient,
                     "openai": OpenAIClient,
+                    "litellm": LiteLLMClient,
                     "openrouter": OpenRouterClient,
                     "ollama": OllamaClient,
                     "bedrock": BedrockClient,

--- a/api/litellm_client.py
+++ b/api/litellm_client.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional, Callable
 from openai import AsyncOpenAI, OpenAI
 
 from api.openai_client import OpenAIClient
@@ -24,36 +25,43 @@ class LiteLLMClient(OpenAIClient):
         ollama/llama3
     """
 
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        chat_completion_parser: Optional[Callable] = None,
+        input_type: str = "text",
+        base_url: Optional[str] = None,
+        env_base_url_name: str = "LITELLM_BASE_URL",
+        env_api_key_name: str = "LITELLM_API_KEY",
+    ):
+        resolved_base_url = base_url or os.getenv(env_base_url_name, "http://localhost:4000")
+        if not resolved_base_url.endswith("/v1"):
+            resolved_base_url = f"{resolved_base_url.rstrip('/')}/v1"
+        super().__init__(
+            api_key=api_key,
+            chat_completion_parser=chat_completion_parser,
+            input_type=input_type,
+            base_url=resolved_base_url,
+            env_base_url_name=env_base_url_name,
+            env_api_key_name=env_api_key_name,
+        )
+
     def init_sync_client(self):
         """
         Initialize synchronous LiteLLM OpenAI-compatible client.
         """
-
-        api_key = os.getenv("LITELLM_API_KEY", "dummy")
-
-        base_url = os.getenv(
-            "LITELLM_BASE_URL",
-            "http://localhost:4000"
-        )
-
+        api_key = self._api_key or os.getenv(self._env_api_key_name, "dummy")
         return OpenAI(
             api_key=api_key,
-            base_url=f"{base_url}/v1",
+            base_url=self.base_url,
         )
 
     def init_async_client(self):
         """
         Initialize asynchronous LiteLLM OpenAI-compatible client.
         """
-
-        api_key = os.getenv("LITELLM_API_KEY", "dummy")
-
-        base_url = os.getenv(
-            "LITELLM_BASE_URL",
-            "http://localhost:4000"
-        )
-
+        api_key = self._api_key or os.getenv(self._env_api_key_name, "dummy")
         return AsyncOpenAI(
             api_key=api_key,
-            base_url=f"{base_url}/v1",
+            base_url=self.base_url,
         )

--- a/api/litellm_client.py
+++ b/api/litellm_client.py
@@ -1,0 +1,59 @@
+import os
+from openai import AsyncOpenAI, OpenAI
+
+from api.openai_client import OpenAIClient
+
+
+class LiteLLMClient(OpenAIClient):
+    """
+    LiteLLM OpenAI-compatible client.
+
+    LiteLLM exposes an OpenAI-compatible API surface, so we can
+    reuse almost all OpenAIClient behavior while overriding only
+    the client initialization.
+
+    Expected environment variables:
+
+    LITELLM_BASE_URL=http://litellm:4000
+    LITELLM_API_KEY=sk-1234
+
+    Example model names:
+        openai/gpt-4o
+        anthropic/claude-3-5-sonnet
+        gemini/gemini-2.5-pro
+        ollama/llama3
+    """
+
+    def init_sync_client(self):
+        """
+        Initialize synchronous LiteLLM OpenAI-compatible client.
+        """
+
+        api_key = os.getenv("LITELLM_API_KEY", "dummy")
+
+        base_url = os.getenv(
+            "LITELLM_BASE_URL",
+            "http://localhost:4000"
+        )
+
+        return OpenAI(
+            api_key=api_key,
+            base_url=f"{base_url}/v1",
+        )
+
+    def init_async_client(self):
+        """
+        Initialize asynchronous LiteLLM OpenAI-compatible client.
+        """
+
+        api_key = os.getenv("LITELLM_API_KEY", "dummy")
+
+        base_url = os.getenv(
+            "LITELLM_BASE_URL",
+            "http://localhost:4000"
+        )
+
+        return AsyncOpenAI(
+            api_key=api_key,
+            base_url=f"{base_url}/v1",
+        )

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -855,9 +855,6 @@ This file contains...
                             fallback_response = await model.acall(api_kwargs=fallback_api_kwargs, model_type=ModelType.LLM)
 
                             # Handle streaming fallback_response from LiteLLM
-                            # async for chunk in fallback_response:
-                            #     text = chunk if isinstance(chunk, str) else getattr(chunk, 'text', str(chunk))
-                            #     await websocket.send_text(text)
                             async for chunk in fallback_response:
                                 choices = getattr(chunk, "choices", [])
                                 if len(choices) > 0:

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -14,12 +14,14 @@ from api.config import (
     configs,
     OPENROUTER_API_KEY,
     OPENAI_API_KEY,
+    LITELLM_API_KEY,
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
 )
 from api.data_pipeline import count_tokens, get_file_content
 from api.bedrock_client import BedrockClient
 from api.openai_client import OpenAIClient
+from api.litellm_client import LiteLLMClient
 from api.openrouter_client import OpenRouterClient
 from api.azureai_client import AzureAIClient
 from api.dashscope_client import DashscopeClient
@@ -505,6 +507,30 @@ This file contains...
                 model_kwargs=model_kwargs,
                 model_type=ModelType.LLM
             )
+        elif request.provider == "litellm":
+            logger.info(f"Using Openai protocol with model on LiteLLM: {request.model}")
+
+            # Check if an API key is set for Litellm
+            if not LITELLM_API_KEY:
+                logger.warning("LITELLM_API_KEY not configured, but continuing with request")
+                # We'll let the OpenAIClient handle this and return an error message
+
+            # Initialize LiteLLM client
+            model = LiteLLMClient()
+            model_kwargs = {
+                "model": request.model,
+                "stream": True,
+                "temperature": model_config["temperature"]
+            }
+            # Only add top_p if it exists in the model config
+            if "top_p" in model_config:
+                model_kwargs["top_p"] = model_config["top_p"]
+
+            api_kwargs = model.convert_inputs_to_api_kwargs(
+                input=prompt,
+                model_kwargs=model_kwargs,
+                model_type=ModelType.LLM
+            )
         elif request.provider == "bedrock":
             logger.info(f"Using AWS Bedrock with model: {request.model}")
 
@@ -637,6 +663,28 @@ This file contains...
                 except Exception as e_openai:
                     logger.error(f"Error with Openai API: {str(e_openai)}")
                     error_msg = f"\nError with Openai API: {str(e_openai)}\n\nPlease check that you have set the OPENAI_API_KEY environment variable with a valid API key."
+                    await websocket.send_text(error_msg)
+                    # Close the WebSocket connection after sending the error message
+                    await websocket.close()
+            elif request.provider == "litellm":
+                try:
+                    # Get the response and handle it properly using the previously created api_kwargs
+                    logger.info("Making LiteLLM API call")
+                    response = await model.acall(api_kwargs=api_kwargs, model_type=ModelType.LLM)
+                    # Handle streaming response from LiteLLM
+                    async for chunk in response:
+                        choices = getattr(chunk, "choices", [])
+                        if len(choices) > 0:
+                            delta = getattr(choices[0], "delta", None)
+                            if delta is not None:
+                                text = getattr(delta, "content", None)
+                                if text is not None:
+                                    await websocket.send_text(text)
+                    # Explicitly close the WebSocket connection after the response is complete
+                    await websocket.close()
+                except Exception as e_litellm:
+                    logger.error(f"Error with LiteLLM API: {str(e_litellm)}")
+                    error_msg = f"\nError with LiteLLM API: {str(e_litellm)}\n\nPlease check that you have set the LITELLM_API_KEY environment variable with a valid API key."
                     await websocket.send_text(error_msg)
                     # Close the WebSocket connection after sending the error message
                     await websocket.close()
@@ -792,6 +840,35 @@ This file contains...
                         except Exception as e_fallback:
                             logger.error(f"Error with Openai API fallback: {str(e_fallback)}")
                             error_msg = f"\nError with Openai API fallback: {str(e_fallback)}\n\nPlease check that you have set the OPENAI_API_KEY environment variable with a valid API key."
+                            await websocket.send_text(error_msg)
+                    elif request.provider == "litellm":
+                        try:
+                            # Create new api_kwargs with the simplified prompt
+                            fallback_api_kwargs = model.convert_inputs_to_api_kwargs(
+                                input=simplified_prompt,
+                                model_kwargs=model_kwargs,
+                                model_type=ModelType.LLM
+                            )
+
+                            # Get the response using the simplified prompt
+                            logger.info("Making fallback LiteLLM API call")
+                            fallback_response = await model.acall(api_kwargs=fallback_api_kwargs, model_type=ModelType.LLM)
+
+                            # Handle streaming fallback_response from LiteLLM
+                            # async for chunk in fallback_response:
+                            #     text = chunk if isinstance(chunk, str) else getattr(chunk, 'text', str(chunk))
+                            #     await websocket.send_text(text)
+                            async for chunk in fallback_response:
+                                choices = getattr(chunk, "choices", [])
+                                if len(choices) > 0:
+                                    delta = getattr(choices[0], "delta", None)
+                                    if delta is not None:
+                                        text = getattr(delta, "content", None)
+                                        if text is not None:
+                                            await websocket.send_text(text)
+                        except Exception as e_fallback:
+                            logger.error(f"Error with LiteLLM API fallback: {str(e_fallback)}")
+                            error_msg = f"\nError with LiteLLM API fallback: {str(e_fallback)}\n\nPlease check that you have set the LITELLM_API_KEY environment variable with a valid API key."
                             await websocket.send_text(error_msg)
                     elif request.provider == "bedrock":
                         try:


### PR DESCRIPTION
**📄 Summary of PR series**:
This PR is part of a 4-PR integration effort to add LiteLLM support to DeepWiki-Open while keeping the system fully backward compatible.

**PR breakdown**:
PR1 – Add optional LiteLLM Docker Compose setup for local LLM gateway
PR2 (current) – Add LiteLLM as a new provider in the application layer
PR3 – LiteLLM Docker/profile setup (wiring PR1 + PR2)
PR4 – Documentation and usage guide updates

**📄 Summary (this PR)**:
This PR introduces LiteLLM as a new LLM provider in DeepWiki-Open using its OpenAI-compatible API interface. It allows DeepWiki to route inference requests through LiteLLM without modifying existing provider implementations.

**🔧 Changes**:
Added LiteLLMClient implementing OpenAI-compatible sync and async clients
Integrated LiteLLM into provider system via config.py
Added litellm provider routing in websocket_wiki.py
Updated provider mapping and environment variable support (LITELLM_API_KEY)

**🧠 Design Notes**:
LiteLLM is treated as a drop-in OpenAI-compatible provider
No changes were made to default providers or existing behavior
Existing OpenAI / OpenRouter / AWS / Google flows remain unchanged
LiteLLM is opt-in via configuration (provider: litellm)

**🔄 Compatibility**:
This change is fully backward compatible:

Default provider behavior is unchanged
Existing deployments do not require LiteLLM
No breaking changes to existing APIs

**🧪 Testing**:

Tested with:
Streaming LLM responses via WebSocket
OpenAI-compatible request flow
Multiple model routing via LiteLLM proxy

**📝 Notes for reviewers**:
This PR focuses strictly on application-level integration
Deployment-specific configuration (Docker profiles, compose overrides) will be handled in follow-up PRs
Embedding support is intentionally kept consistent with existing provider abstraction