### PR TITLE
Replace [DEEP RESEARCH] content tag with explicit `mode` and `research_iteration` fields

### DIFF
--- a/api/chat_model.py
+++ b/api/chat_model.py
@@ -27,6 +27,13 @@ class ChatCompletionRequest(BaseModel):
     model: Optional[str] = Field(None, description="Model name for the specified provider")
 
     language: Optional[str] = Field("en", description="Language for content generation (e.g., 'en', 'ja', 'zh', 'es', 'kr', 'vi')")
+
+    research_iteration: int = Field(
+        default=1,
+        ge=1,
+        description="Current deep research iteration (1-based). Only used when the request is in deep_research mode.",
+    )
+
     excluded_dirs: List[str] = Field(
         default_factory=list,
         description="List or newline-separated string of directories to exclude from processing",

--- a/api/chat_model.py
+++ b/api/chat_model.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, field_validator
 class ChatMessage(BaseModel):
     role: str  # 'user' or 'assistant'
     content: str
+    mode: Literal["normal", "deep_research"] = Field(default="normal")
 
 class ChatCompletionRequest(BaseModel):
     """

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -117,21 +117,10 @@ async def chat_completions_stream(request: ChatCompletionRequest):
 
         # Check if this is a Deep Research request
         is_deep_research = last_message.mode == "deep_research"
-        research_iteration = 1
 
         # Count research iterations if this is a Deep Research request
         if is_deep_research:
-            # only count the assistant turns within the current deep research streak, so that mode switched
-            # before wouldn't inflate the current research iteration
-            current_streak = 0
-            for msg in reversed(request.messages):
-                if msg.role == "user" and msg.mode != "deep_research":
-                    break
-                if msg.role == "assistant":
-                    current_streak += 1
-
-            research_iteration = current_streak + 1
-            logger.info(f"Deep Research request detected - iteration {research_iteration}")
+            logger.info("Deep Research request detected - iteration %d",request.research_iteration)
 
             # Check if this is a continuation request
             if "continue" in last_message.content.lower() and "research" in last_message.content.lower():
@@ -219,10 +208,10 @@ async def chat_completions_stream(request: ChatCompletionRequest):
         # Create system prompt
         if is_deep_research:
             # Check if this is the first iteration
-            is_first_iteration = research_iteration == 1
+            is_first_iteration = request.research_iteration == 1
 
             # Check if this is the final iteration
-            is_final_iteration = research_iteration >= 5
+            is_final_iteration = request.research_iteration >= 5
 
             if is_first_iteration:
                 system_prompt = DEEP_RESEARCH_FIRST_ITERATION_PROMPT.format(
@@ -243,7 +232,7 @@ async def chat_completions_stream(request: ChatCompletionRequest):
                     repo_type=repo_type,
                     repo_url=repo_url,
                     repo_name=repo_name,
-                    research_iteration=research_iteration,
+                    research_iteration=request.research_iteration,
                     language_name=language_name
                 )
         else:

--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -116,21 +116,21 @@ async def chat_completions_stream(request: ChatCompletionRequest):
                     )
 
         # Check if this is a Deep Research request
-        is_deep_research = False
+        is_deep_research = last_message.mode == "deep_research"
         research_iteration = 1
-
-        # Process messages to detect Deep Research requests
-        for msg in request.messages:
-            if hasattr(msg, 'content') and msg.content and "[DEEP RESEARCH]" in msg.content:
-                is_deep_research = True
-                # Only remove the tag from the last message
-                if msg == request.messages[-1]:
-                    # Remove the Deep Research tag
-                    msg.content = msg.content.replace("[DEEP RESEARCH]", "").strip()
 
         # Count research iterations if this is a Deep Research request
         if is_deep_research:
-            research_iteration = sum(1 for msg in request.messages if msg.role == 'assistant') + 1
+            # only count the assistant turns within the current deep research streak, so that mode switched
+            # before wouldn't inflate the current research iteration
+            current_streak = 0
+            for msg in reversed(request.messages):
+                if msg.role == "user" and msg.mode != "deep_research":
+                    break
+                if msg.role == "assistant":
+                    current_streak += 1
+
+            research_iteration = current_streak + 1
             logger.info(f"Deep Research request detected - iteration {research_iteration}")
 
             # Check if this is a continuation request
@@ -139,7 +139,7 @@ async def chat_completions_stream(request: ChatCompletionRequest):
                 original_topic = None
                 for msg in request.messages:
                     if msg.role == "user" and "continue" not in msg.content.lower():
-                        original_topic = msg.content.replace("[DEEP RESEARCH]", "").strip()
+                        original_topic = msg.content.strip()
                         logger.info(f"Found original research topic: {original_topic}")
                         break
 

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -119,21 +119,21 @@ async def handle_websocket_chat(websocket: WebSocket):
                     )
 
         # Check if this is a Deep Research request
-        is_deep_research = False
+        is_deep_research = last_message.mode == "deep_research"
         research_iteration = 1
-
-        # Process messages to detect Deep Research requests
-        for msg in request.messages:
-            if hasattr(msg, 'content') and msg.content and "[DEEP RESEARCH]" in msg.content:
-                is_deep_research = True
-                # Only remove the tag from the last message
-                if msg == request.messages[-1]:
-                    # Remove the Deep Research tag
-                    msg.content = msg.content.replace("[DEEP RESEARCH]", "").strip()
 
         # Count research iterations if this is a Deep Research request
         if is_deep_research:
-            research_iteration = sum(1 for msg in request.messages if msg.role == 'assistant') + 1
+            # only count the assistant turns within the current deep research streak, so that mode switched
+            # before wouldn't inflate the current research iteration
+            current_streak = 0
+            for msg in reversed(request.messages):
+                if msg.role == "user" and msg.mode != "deep_research":
+                    break
+                if msg.role == "assistant":
+                    current_streak += 1
+
+            research_iteration = current_streak + 1
             logger.info(f"Deep Research request detected - iteration {research_iteration}")
 
             # Check if this is a continuation request
@@ -142,7 +142,7 @@ async def handle_websocket_chat(websocket: WebSocket):
                 original_topic = None
                 for msg in request.messages:
                     if msg.role == "user" and "continue" not in msg.content.lower():
-                        original_topic = msg.content.replace("[DEEP RESEARCH]", "").strip()
+                        original_topic = msg.content.strip()
                         logger.info(f"Found original research topic: {original_topic}")
                         break
 

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -120,21 +120,10 @@ async def handle_websocket_chat(websocket: WebSocket):
 
         # Check if this is a Deep Research request
         is_deep_research = last_message.mode == "deep_research"
-        research_iteration = 1
 
         # Count research iterations if this is a Deep Research request
         if is_deep_research:
-            # only count the assistant turns within the current deep research streak, so that mode switched
-            # before wouldn't inflate the current research iteration
-            current_streak = 0
-            for msg in reversed(request.messages):
-                if msg.role == "user" and msg.mode != "deep_research":
-                    break
-                if msg.role == "assistant":
-                    current_streak += 1
-
-            research_iteration = current_streak + 1
-            logger.info(f"Deep Research request detected - iteration {research_iteration}")
+            logger.info("Deep Research request detected - iteration %d", request.research_iteration)
 
             # Check if this is a continuation request
             if "continue" in last_message.content.lower() and "research" in last_message.content.lower():
@@ -222,10 +211,10 @@ async def handle_websocket_chat(websocket: WebSocket):
         # Create system prompt
         if is_deep_research:
             # Check if this is the first iteration
-            is_first_iteration = research_iteration == 1
+            is_first_iteration = request.research_iteration == 1
 
             # Check if this is the final iteration
-            is_final_iteration = research_iteration >= 5
+            is_final_iteration = request.research_iteration >= 5
 
             if is_first_iteration:
                 system_prompt = DEEP_RESEARCH_FIRST_ITERATION_PROMPT.format(
@@ -246,7 +235,7 @@ async def handle_websocket_chat(websocket: WebSocket):
                     repo_type=repo_type,
                     repo_url=repo_url,
                     repo_name=repo_name,
-                    research_iteration=research_iteration,
+                    research_iteration=request.research_iteration,
                     language_name=language_name
                 )
         else:

--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -326,7 +326,8 @@ const Ask: React.FC<AskProps> = ({
         })),
         provider: selectedProvider,
         model: isCustomSelectedModel ? customSelectedModel : selectedModel,
-        language: language
+        language: language,
+        research_iteration: newIteration
       };
 
       // Add tokens if available
@@ -573,7 +574,8 @@ const Ask: React.FC<AskProps> = ({
         })),
         provider: selectedProvider,
         model: isCustomSelectedModel ? customSelectedModel : selectedModel,
-        language: language
+        language: language,
+        research_iteration: deepResearch ? 1 : undefined
       };
 
       // Add tokens if available

--- a/src/components/Ask.tsx
+++ b/src/components/Ask.tsx
@@ -24,6 +24,7 @@ interface Provider {
 interface Message {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  mode?: 'normal' | 'deep_research';
 }
 
 interface ResearchStage {
@@ -299,7 +300,8 @@ const Ask: React.FC<AskProps> = ({
         },
         {
           role: 'user',
-          content: '[DEEP RESEARCH] Continue the research'
+          content: 'Continue the research',
+          mode: 'deep_research'
         }
       ];
 
@@ -317,7 +319,11 @@ const Ask: React.FC<AskProps> = ({
       const requestBody: ChatCompletionRequest = {
         repo_url: getRepoUrl(repoInfo),
         type: repoInfo.type,
-        messages: newHistory.map(msg => ({ role: msg.role as 'user' | 'assistant', content: msg.content })),
+        messages: newHistory.map(msg => ({
+          role: msg.role as 'user' | 'assistant',
+          content: msg.content,
+          mode: msg.mode ?? 'normal',
+        })),
         provider: selectedProvider,
         model: isCustomSelectedModel ? customSelectedModel : selectedModel,
         language: language
@@ -548,7 +554,8 @@ const Ask: React.FC<AskProps> = ({
       // Create initial message
       const initialMessage: Message = {
         role: 'user',
-        content: deepResearch ? `[DEEP RESEARCH] ${question}` : question
+        content: question,
+        mode: deepResearch ? 'deep_research' : 'normal'
       };
 
       // Set initial conversation history
@@ -559,7 +566,11 @@ const Ask: React.FC<AskProps> = ({
       const requestBody: ChatCompletionRequest = {
         repo_url: getRepoUrl(repoInfo),
         type: repoInfo.type,
-        messages: newHistory.map(msg => ({ role: msg.role as 'user' | 'assistant', content: msg.content })),
+        messages: newHistory.map(msg => ({
+          role: msg.role as 'user' | 'assistant',
+          content: msg.content,
+          mode: msg.mode ?? 'normal'
+        })),
         provider: selectedProvider,
         model: isCustomSelectedModel ? customSelectedModel : selectedModel,
         language: language

--- a/src/utils/websocketClient.ts
+++ b/src/utils/websocketClient.ts
@@ -29,6 +29,7 @@ export interface ChatCompletionRequest {
   provider?: string;
   model?: string;
   language?: string;
+  research_iteration?: number;
   excluded_dirs?: string;
   excluded_files?: string;
 }

--- a/src/utils/websocketClient.ts
+++ b/src/utils/websocketClient.ts
@@ -17,6 +17,7 @@ const getWebSocketUrl = () => {
 export interface ChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  mode?: 'normal' | 'deep_research';
 }
 
 export interface ChatCompletionRequest {


### PR DESCRIPTION
# Summary
Deep Research mode and its iteration count were previously inferred from message content — a [DEEP RESEARCH] string was prepended to the message, and the backend counted messages to derive the iteration. This replaces both with explicit, typed request fields, removing all string-parsing and message-counting heuristics.

## Backend
* `ChatMessage` gains `mode: Literal["normal", "deep_research"]` (default to `"normal"`)
* `ChatCompletionRequest` gains `research_iteration`: int (defaults to 1, ge=1).
* `simple_chat.py` / `websocket_wiki.py`:
  * The active mode is now read directly from the last message (last_message.mode), which is guaranteed to be the user's current turn — no more scanning/stripping the [DEEP RESEARCH] tag.
  * The deep research iteration is now taken from `request.research_iteration` instead of counting assistant turns, so a brand-new deep research question always restarts at iteration 1 regardless of prior history.

## Frontend
* `ChatMessage` / `Message` interfaces gain an optional `mode` field
* `ChatCompletionRequest` gains an optional `research_iteration` field.
* `Ask.tsx` now sets mode: `deep_research` instead of prefixing content with the tag, and sends `research_iteration` explicitly (1 on initial submit, the incremented value on auto-continue).