### PR TITLE
fix callers of `count_tokens`

### DIFF
--- a/api/simple_chat.py
+++ b/api/simple_chat.py
@@ -50,7 +50,7 @@ async def chat_completions_stream(request: ChatCompletionRequest):
         if request.messages and len(request.messages) > 0:
             last_message = request.messages[-1]
             if hasattr(last_message, 'content') and last_message.content:
-                tokens = count_tokens(last_message.content, request.provider == "ollama")
+                tokens = count_tokens(last_message.content, embedder_type=request.provider)
                 logger.info(f"Request size: {tokens} tokens")
                 if tokens > MAX_INPUT_TOKENS:
                     logger.warning(f"Request exceeds recommended token limit ({tokens} > {MAX_INPUT_TOKENS})")

--- a/api/websocket_wiki.py
+++ b/api/websocket_wiki.py
@@ -43,7 +43,7 @@ async def handle_websocket_chat(websocket: WebSocket):
         if request.messages and len(request.messages) > 0:
             last_message = request.messages[-1]
             if hasattr(last_message, 'content') and last_message.content:
-                tokens = count_tokens(last_message.content, request.provider == "ollama")
+                tokens = count_tokens(last_message.content, embedder_type=request.provider)
                 logger.info(f"Request size: {tokens} tokens")
                 if tokens > MAX_INPUT_TOKENS:
                     logger.warning(f"Request exceeds recommended token limit ({tokens} > {MAX_INPUT_TOKENS})")


### PR DESCRIPTION
# Summary
Fix callers in `simple_chat.py` and `websocket_wiki.py` calling signature. Since the input signatures are as follows

```python
def count_tokens(text: str, embedder_type: str = None, is_ollama_embedder: bool = None) -> int:
```

passing a bool value to the `embedder_type` is missleading. Change to  pass provider string directly.