### PR TITLE
Fix: add back default `local` repo type in `ChatCompletionRequest`

### DIFF
--- a/api/chat_model.py
+++ b/api/chat_model.py
@@ -18,7 +18,7 @@ class ChatCompletionRequest(BaseModel):
     token: Optional[str] = Field(None, description="Personal access token for private repositories")
     type: Optional[Literal["local", "github", "gitlab", "bitbucket"]] = Field(
         "github",
-        description="Type of repository (e.g., 'github', 'gitlab', 'bitbucket')",
+        description="Type of repository (e.g., 'local', 'github', 'gitlab', 'bitbucket')",
     )
 
     # model parameters

--- a/api/chat_model.py
+++ b/api/chat_model.py
@@ -16,7 +16,7 @@ class ChatCompletionRequest(BaseModel):
     messages: List[ChatMessage] = Field(..., description="List of chat messages")
     filePath: Optional[str] = Field(None, description="Optional path to a file in the repository to include in the prompt")
     token: Optional[str] = Field(None, description="Personal access token for private repositories")
-    type: Optional[Literal["github", "gitlab", "bitbucket"]] = Field(
+    type: Optional[Literal["local", "github", "gitlab", "bitbucket"]] = Field(
         "github",
         description="Type of repository (e.g., 'github', 'gitlab', 'bitbucket')",
     )


### PR DESCRIPTION
# Summary
in #550, I missed adding `local` repo type in `ChatCompletionRequest`. This would cause pydantic validation error when sending request for indexing a new local repo.