### PR TITLE
fix: handle Responses API event shape in OpenAI stream

### DIFF
--- a/api/chat/_stream.py
+++ b/api/chat/_stream.py
@@ -165,13 +165,21 @@ class _OpenAICompatStreamer(ChatStreamer):
         )
 
         async for chunk in response:
-            if (
-                chunk.choices
-                and chunk.choices[0].delta is not None
-                and chunk.choices[0].delta.content is not None
-            ):
-                yield chunk.choices[0].delta.content
+            # Responses API event shape
+            if getattr(chunk, "type", "") == "response.output_text.delta":
+                delta = getattr(chunk, "delta", None)
+                if delta:
+                    yield delta
+                continue
 
+            # Chat Completions chunk shape
+            choices = getattr(chunk, "choices", None)
+            if (
+                choices
+                and choices[0].delta is not None
+                and choices[0].delta.content is not None
+            ):
+                yield choices[0].delta.content
 
 class OpenAIChatStreamer(_OpenAICompatStreamer):
     provider = "openai"


### PR DESCRIPTION
Fixes #585

## Problem

`respond_stream` in the OpenAI streamer consumes the stream assuming
Chat Completions chunks, but adalflow returns Responses API events,
which have no `choices` attribute:

`File "/app/api/chat/_stream.py", line 169, in respond_stream
chunk.choices
AttributeError: 'ResponseCreatedEvent' object has no attribute 'choices'`

The stream raises on the first event, before yielding any text, so the
downstream structure parser then fails with a misleading
`No valid <wiki_structure> XML found in response`.

## Fix

Handle both event shapes in the loop, using `getattr` so neither
attribute access can raise. Unknown event types (`response.created`,
`response.completed`) fall through both branches and are ignored.

The Anthropic streamer in the same file is untouched — it already
reads its own provider's event shape correctly.


## Testing

Built from this branch and generated a wiki successfully with the
OpenAI provider. Previously failed on every attempt.